### PR TITLE
fix: 当API URL为空时使用默认币种列表，避免循环请求失败

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,11 @@ Create `config.json` file (use `config.json.example` as template):
 - `binance_api_key/secret_key`: Each trader uses independent Binance account
 - `initial_balance`: Initial balance (for calculating P/L%)
 - `scan_interval_minutes`: Decision cycle (recommended 3-5 minutes)
-- `coin_pool_api_url`: AI500 coin pool API (optional, if empty, uses default mainstream coins)
+- `use_default_coins`: **true** = Use default 8 mainstream coins | **false** = Use API coin pool (recommended for beginners: true)
+- `coin_pool_api_url`: AI500 coin pool API (optional, ignored when use_default_coins=true)
 - `oi_top_api_url`: OI Top open interest API (optional, if empty, OI Top data is skipped)
 
-**Default Coin List** (used when APIs are not configured):
+**Default Coin List** (when `use_default_coins: true`):
 - BTC, ETH, SOL, BNB, XRP, DOGE, ADA, HYPE
 
 ### 5. Run the System

--- a/README.ru.md
+++ b/README.ru.md
@@ -173,11 +173,26 @@ cd ..
       "initial_balance": 1000.0
     }
   ],
+  "use_default_coins": false,
   "coin_pool_api_url": "http://x.x.x.x:xxx/api/ai500/list?auth=ВАШ_AUTH",
   "oi_top_api_url": "http://x.x.x.x:xxx/api/oi/top?auth=ВАШ_AUTH",
   "api_server_port": 8080
 }
 ```
+
+**Примечания к конфигурации:**
+- `traders`: Настройте 1-N трейдеров (один AI или соревнование нескольких AI)
+- `id`: Уникальный идентификатор трейдера (используется для директории логов)
+- `ai_model`: "qwen" или "deepseek"
+- `binance_api_key/secret_key`: Каждый трейдер использует независимый аккаунт Binance
+- `initial_balance`: Начальный баланс (для расчета P/L%)
+- `scan_interval_minutes`: Цикл принятия решений (рекомендуется 3-5 минут)
+- `use_default_coins`: **true** = Использовать 8 основных монет по умолчанию | **false** = Использовать API пул монет (рекомендуется для новичков: true)
+- `coin_pool_api_url`: API пула монет AI500 (опционально, игнорируется при use_default_coins=true)
+- `oi_top_api_url`: API открытого интереса OI Top (опционально, если пусто, данные OI Top пропускаются)
+
+**Список монет по умолчанию** (когда `use_default_coins: true`):
+- BTC, ETH, SOL, BNB, XRP, DOGE, ADA, HYPE
 
 ### 5. Запуск системы
 

--- a/README.uk.md
+++ b/README.uk.md
@@ -173,11 +173,26 @@ cd ..
       "initial_balance": 1000.0
     }
   ],
+  "use_default_coins": false,
   "coin_pool_api_url": "http://x.x.x.x:xxx/api/ai500/list?auth=ВАШ_AUTH",
   "oi_top_api_url": "http://x.x.x.x:xxx/api/oi/top?auth=ВАШ_AUTH",
   "api_server_port": 8080
 }
 ```
+
+**Примітки до конфігурації:**
+- `traders`: Налаштуйте 1-N трейдерів (один AI або змагання кількох AI)
+- `id`: Унікальний ідентифікатор трейдера (використовується для директорії логів)
+- `ai_model`: "qwen" або "deepseek"
+- `binance_api_key/secret_key`: Кожен трейдер використовує незалежний акаунт Binance
+- `initial_balance`: Початковий баланс (для розрахунку P/L%)
+- `scan_interval_minutes`: Цикл прийняття рішень (рекомендується 3-5 хвилин)
+- `use_default_coins`: **true** = Використовувати 8 основних монет за замовчуванням | **false** = Використовувати API пул монет (рекомендується для новачків: true)
+- `coin_pool_api_url`: API пулу монет AI500 (опціонально, ігнорується при use_default_coins=true)
+- `oi_top_api_url`: API відкритого інтересу OI Top (опціонально, якщо порожньо, дані OI Top пропускаються)
+
+**Список монет за замовчуванням** (коли `use_default_coins: true`):
+- BTC, ETH, SOL, BNB, XRP, DOGE, ADA, HYPE
 
 ### 5. Запуск системи
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -250,10 +250,11 @@ cd ..
 - `binance_api_key/secret_key`: 每个trader使用独立的币安账户
 - `initial_balance`: 初始余额（用于计算盈亏%）
 - `scan_interval_minutes`: 决策周期（建议3-5分钟）
-- `coin_pool_api_url`: AI500币种池API（可选，留空时使用默认主流币种）
+- `use_default_coins`: **true** = 使用默认8个主流币种 | **false** = 使用API币种池（新手推荐：true）
+- `coin_pool_api_url`: AI500币种池API（可选，当use_default_coins=true时忽略）
 - `oi_top_api_url`: OI Top持仓量API（可选，留空时跳过OI Top数据）
 
-**默认币种列表**（当API未配置时使用）：
+**默认币种列表**（当 `use_default_coins: true` 时）：
 - BTC、ETH、SOL、BNB、XRP、DOGE、ADA、HYPE
 
 ### 5. 运行系统

--- a/config.json.example
+++ b/config.json.example
@@ -21,6 +21,7 @@
       "scan_interval_minutes": 3
     }
   ],
+  "use_default_coins": false,
   "coin_pool_api_url": "http://x.x.x.x:x/api/ai500/list?auth=",
   "oi_top_api_url": "http://x.x.x.x:x/api/oi/top?auth=",
   "api_server_port": 8080,

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type TraderConfig struct {
 // Config 总配置
 type Config struct {
 	Traders            []TraderConfig `json:"traders"`
+	UseDefaultCoins    bool           `json:"use_default_coins"`     // 是否使用默认主流币种列表
 	CoinPoolAPIURL     string         `json:"coin_pool_api_url"`
 	OITopAPIURL        string         `json:"oi_top_api_url"`
 	APIServerPort      int            `json:"api_server_port"`

--- a/main.go
+++ b/main.go
@@ -34,6 +34,12 @@ func main() {
 	log.Printf("✓ 配置加载成功，共%d个trader参赛", len(cfg.Traders))
 	fmt.Println()
 
+	// 设置是否使用默认主流币种
+	pool.SetUseDefaultCoins(cfg.UseDefaultCoins)
+	if cfg.UseDefaultCoins {
+		log.Printf("✓ 已启用默认主流币种列表（BTC、ETH、SOL、BNB、XRP、DOGE、ADA、HYPE）")
+	}
+
 	// 设置币种池API URL
 	if cfg.CoinPoolAPIURL != "" {
 		pool.SetCoinPoolAPI(cfg.CoinPoolAPIURL)

--- a/pool/coin_pool.go
+++ b/pool/coin_pool.go
@@ -26,15 +26,17 @@ var defaultMainstreamCoins = []string{
 
 // CoinPoolConfig 币种池配置
 type CoinPoolConfig struct {
-	APIURL   string
-	Timeout  time.Duration
-	CacheDir string
+	APIURL          string
+	Timeout         time.Duration
+	CacheDir        string
+	UseDefaultCoins bool // 是否使用默认主流币种
 }
 
 var coinPoolConfig = CoinPoolConfig{
-	APIURL:   "",
-	Timeout:  30 * time.Second, // 增加到30秒
-	CacheDir: "coin_pool_cache",
+	APIURL:          "",
+	Timeout:         30 * time.Second, // 增加到30秒
+	CacheDir:        "coin_pool_cache",
+	UseDefaultCoins: false, // 默认不使用
 }
 
 // CoinPoolCache 币种池缓存
@@ -76,8 +78,19 @@ func SetOITopAPI(apiURL string) {
 	oiTopConfig.APIURL = apiURL
 }
 
+// SetUseDefaultCoins 设置是否使用默认主流币种
+func SetUseDefaultCoins(useDefault bool) {
+	coinPoolConfig.UseDefaultCoins = useDefault
+}
+
 // GetCoinPool 获取币种池列表（带重试和缓存机制）
 func GetCoinPool() ([]CoinInfo, error) {
+	// 优先检查是否启用默认币种列表
+	if coinPoolConfig.UseDefaultCoins {
+		log.Printf("✓ 已启用默认主流币种列表")
+		return convertSymbolsToCoins(defaultMainstreamCoins), nil
+	}
+
 	// 检查API URL是否配置
 	if strings.TrimSpace(coinPoolConfig.APIURL) == "" {
 		log.Printf("⚠️  未配置币种池API URL，使用默认主流币种列表")


### PR DESCRIPTION
- 添加默认主流币种列表（BTC、ETH、SOL、BNB、XRP、DOGE、ADA、HYPE）
- 在GetCoinPool()中检查coin_pool_api_url，为空时直接返回默认列表
- 在GetOITopPositions()中检查oi_top_api_url，为空时跳过OI Top数据
- 更新README文档，说明API URL可选配置和默认币种列表
- 修复：避免空URL导致的循环请求和"unsupported protocol scheme"错误