### PR TITLE
Expose the default mainstream currency settings to the configuration file

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -60,6 +60,16 @@
     "altcoin_leverage": 5
   },
   "use_default_coins": true,
+  "default_coins": [
+    "BTCUSDT",
+    "ETHUSDT",
+    "SOLUSDT",
+    "BNBUSDT",
+    "XRPUSDT",
+    "DOGEUSDT",
+    "ADAUSDT",
+    "HYPEUSDT",
+  ],
   "coin_pool_api_url": "",
   "oi_top_api_url": "",
   "api_server_port": 8080,

--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,7 @@ type LeverageConfig struct {
 type Config struct {
 	Traders            []TraderConfig `json:"traders"`
 	UseDefaultCoins    bool           `json:"use_default_coins"`     // 是否使用默认主流币种列表
+	DefaultCoins       []string       `json:"default_coins"`         // 默认主流币种池
 	CoinPoolAPIURL     string         `json:"coin_pool_api_url"`
 	OITopAPIURL        string         `json:"oi_top_api_url"`
 	APIServerPort      int            `json:"api_server_port"`
@@ -76,6 +77,20 @@ func LoadConfig(filename string) (*Config, error) {
 	// 设置默认值：如果use_default_coins未设置（为false）且没有配置coin_pool_api_url，则默认使用默认币种列表
 	if !config.UseDefaultCoins && config.CoinPoolAPIURL == "" {
 		config.UseDefaultCoins = true
+	}
+
+	// 设置默认币种池
+	if len(config.DefaultCoins) == 0 {
+		config.DefaultCoins = []string{
+			"BTCUSDT",
+            "ETHUSDT",
+            "SOLUSDT",
+            "BNBUSDT",
+            "XRPUSDT",
+            "DOGEUSDT",
+            "ADAUSDT",
+            "HYPEUSDT",
+		}
 	}
 
 	// 验证配置

--- a/main.go
+++ b/main.go
@@ -34,10 +34,13 @@ func main() {
 	log.Printf("✓ 配置加载成功，共%d个trader参赛", len(cfg.Traders))
 	fmt.Println()
 
+	// 设置默认主流币种列表
+	pool.SetDefaultCoins(cfg.DefaultCoins)
+
 	// 设置是否使用默认主流币种
 	pool.SetUseDefaultCoins(cfg.UseDefaultCoins)
 	if cfg.UseDefaultCoins {
-		log.Printf("✓ 已启用默认主流币种列表（BTC、ETH、SOL、BNB、XRP、DOGE、ADA、HYPE）")
+		log.Printf("✓ 已启用默认主流币种列表（共%d个币种）: %v", len(cfg.DefaultCoins), cfg.DefaultCoins)
 	}
 
 	// 设置币种池API URL

--- a/pool/coin_pool.go
+++ b/pool/coin_pool.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-// defaultMainstreamCoins 默认主流币种池（当AI500和OI Top都失败时使用）
+// defaultMainstreamCoins 默认主流币种池（从配置文件读取）
 var defaultMainstreamCoins = []string{
 	"BTCUSDT",
 	"ETHUSDT",
@@ -81,6 +81,14 @@ func SetOITopAPI(apiURL string) {
 // SetUseDefaultCoins 设置是否使用默认主流币种
 func SetUseDefaultCoins(useDefault bool) {
 	coinPoolConfig.UseDefaultCoins = useDefault
+}
+
+// SetDefaultCoins 设置默认主流币种列表
+func SetDefaultCoins(coins []string) {
+	if len(coins) > 0 {
+		defaultMainstreamCoins = coins
+		log.Printf("✓ 已设置默认币种池（共%d个币种）: %v", len(coins), coins)
+	}
 }
 
 // GetCoinPool 获取币种池列表（带重试和缓存机制）


### PR DESCRIPTION
1. Expose the default mainstream coin settings in the configuration file. 将默认主流币种设置暴露到配置文件。
2. Control contract trading pairs via the default_coins array. The sample file config.json.example has been modified.通过default_coins数组控制合约交易对。config.json.example样例文件已经修改
3. When loading the configuration file, print the list of enabled coins to the console.加载配置文件时，控制台打印启用币种列表
