### PR TITLE
Reduce the request frequency to the Binance API and add backend caching.

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,9 +42,9 @@ function App() {
       : null,
     () => api.getStatus(selectedTraderId),
     {
-      refreshInterval: 5000,
-      revalidateOnFocus: true,
-      dedupingInterval: 0,
+      refreshInterval: 15000, // 15秒刷新（配合后端15秒缓存）
+      revalidateOnFocus: false, // 禁用聚焦时重新验证，减少请求
+      dedupingInterval: 10000, // 10秒去重，防止短时间内重复请求
     }
   );
 
@@ -54,9 +54,9 @@ function App() {
       : null,
     () => api.getAccount(selectedTraderId),
     {
-      refreshInterval: 5000,
-      revalidateOnFocus: true,
-      dedupingInterval: 0,
+      refreshInterval: 15000, // 15秒刷新（配合后端15秒缓存）
+      revalidateOnFocus: false, // 禁用聚焦时重新验证，减少请求
+      dedupingInterval: 10000, // 10秒去重，防止短时间内重复请求
     }
   );
 
@@ -66,9 +66,9 @@ function App() {
       : null,
     () => api.getPositions(selectedTraderId),
     {
-      refreshInterval: 5000,
-      revalidateOnFocus: true,
-      dedupingInterval: 0,
+      refreshInterval: 15000, // 15秒刷新（配合后端15秒缓存）
+      revalidateOnFocus: false, // 禁用聚焦时重新验证，减少请求
+      dedupingInterval: 10000, // 10秒去重，防止短时间内重复请求
     }
   );
 
@@ -77,7 +77,11 @@ function App() {
       ? `decisions/latest-${selectedTraderId}`
       : null,
     () => api.getLatestDecisions(selectedTraderId),
-    { refreshInterval: 10000 }
+    {
+      refreshInterval: 30000, // 30秒刷新（决策更新频率较低）
+      revalidateOnFocus: false,
+      dedupingInterval: 20000,
+    }
   );
 
   const { data: stats } = useSWR<Statistics>(
@@ -85,7 +89,11 @@ function App() {
       ? `statistics-${selectedTraderId}`
       : null,
     () => api.getStatistics(selectedTraderId),
-    { refreshInterval: 10000 }
+    {
+      refreshInterval: 30000, // 30秒刷新（统计数据更新频率较低）
+      revalidateOnFocus: false,
+      dedupingInterval: 20000,
+    }
   );
 
   useEffect(() => {

--- a/web/src/components/AILearning.tsx
+++ b/web/src/components/AILearning.tsx
@@ -50,7 +50,11 @@ export default function AILearning({ traderId }: AILearningProps) {
   const { data: performance, error } = useSWR<PerformanceAnalysis>(
     traderId ? `performance-${traderId}` : 'performance',
     () => api.getPerformance(traderId),
-    { refreshInterval: 10000 }
+    {
+      refreshInterval: 30000, // 30秒刷新（AI学习分析数据更新频率较低）
+      revalidateOnFocus: false,
+      dedupingInterval: 20000,
+    }
   );
 
   if (error) {

--- a/web/src/components/ComparisonChart.tsx
+++ b/web/src/components/ComparisonChart.tsx
@@ -33,8 +33,9 @@ export function ComparisonChart({ traders }: ComparisonChartProps) {
       return Promise.all(promises);
     },
     {
-      refreshInterval: 10000,
+      refreshInterval: 30000, // 30秒刷新（对比图表数据更新频率较低）
       revalidateOnFocus: false,
+      dedupingInterval: 20000,
     }
   );
 

--- a/web/src/components/CompetitionPage.tsx
+++ b/web/src/components/CompetitionPage.tsx
@@ -11,8 +11,9 @@ export function CompetitionPage() {
     'competition',
     api.getCompetition,
     {
-      refreshInterval: 5000,
-      revalidateOnFocus: true,
+      refreshInterval: 15000, // 15秒刷新（竞赛数据不需要太频繁更新）
+      revalidateOnFocus: false,
+      dedupingInterval: 10000,
     }
   );
 

--- a/web/src/components/EquityChart.tsx
+++ b/web/src/components/EquityChart.tsx
@@ -34,7 +34,9 @@ export function EquityChart({ traderId }: EquityChartProps) {
     traderId ? `equity-history-${traderId}` : 'equity-history',
     () => api.getEquityHistory(traderId),
     {
-      refreshInterval: 10000, // 每10秒刷新
+      refreshInterval: 30000, // 30秒刷新（历史数据更新频率较低）
+      revalidateOnFocus: false,
+      dedupingInterval: 20000,
     }
   );
 
@@ -42,7 +44,9 @@ export function EquityChart({ traderId }: EquityChartProps) {
     traderId ? `account-${traderId}` : 'account',
     () => api.getAccount(traderId),
     {
-      refreshInterval: 5000,
+      refreshInterval: 15000, // 15秒刷新（配合后端缓存）
+      revalidateOnFocus: false,
+      dedupingInterval: 10000,
     }
   );
 


### PR DESCRIPTION
📊 Issues before optimization

  - Frontend: requests account info every 5 seconds, no deduplication
  - Backend: no caching, calls the Binance API each time
  - Result: a single trader calls the Binance API 36 times per minute

  🚀 Implemented optimizations

  1. Backend caching mechanism (binance_futures.go)

  Added features:
  - ✅ Account balance cache (15-second TTL)
  - ✅ Positions info cache (15-second TTL)
  - ✅ Thread-safe read-write lock mechanism
  - ✅ Smart cache logging (shows cache hits and API calls)

  How it works:
  First request → call Binance API → cache for 15 seconds
  Subsequent requests (within 15 seconds) → return cache directly ✓
  After cache expires → call API again → update cache

  2. Frontend request frequency optimization

  | Endpoint type     | Before        | After              | Reduction |
  |-------------------|---------------|--------------------|-----------|
  | account           | 5s, no dedupe | 15s + 10s deduping | 67% ↓     |
  | status            | 5s, no dedupe | 15s + 10s deduping | 67% ↓     |
  | positions         | 5s, no dedupe | 15s + 10s deduping | 67% ↓     |
  | decisions         | 10s           | 30s + 20s deduping | 67% ↓     |
  | statistics        | 10s           | 30s + 20s deduping | 67% ↓     |
  | equity-history    | 10s           | 30s + 20s deduping | 67% ↓     |
  | performance       | 10s           | 30s + 20s deduping | 67% ↓     |
  | competition       | 5s            | 15s + 10s deduping | 67% ↓     |

  New configurations:
  - revalidateOnFocus: false - disable revalidation on page focus
  - dedupingInterval - prevent duplicate requests within a short time


📊 优化前的问题

  - 前端：每5秒请求一次账户信息，不去重
  - 后端：没有缓存，每次直接调用币安API
  - 结果：单个Trader每分钟调用币安API 36次

  🚀 实施的优化

  1. 后端缓存机制 (binance_futures.go)

  添加的功能：
  - ✅ 账户余额缓存（15秒有效期）
  - ✅ 持仓信息缓存（15秒有效期）
  - ✅ 线程安全的读写锁机制
  - ✅ 智能缓存日志（显示缓存命中和API调用）

  工作原理：
  第一次请求 → 调用币安API → 缓存15秒
  后续请求（15秒内） → 直接返回缓存 ✓
  缓存过期后 → 重新调用API → 更新缓存

  2. 前端请求频率优化

  | 接口类型           | 优化前    | 优化后         | 减少幅度  |
  |----------------|--------|-------------|-------|
  | account        | 5秒，不去重 | 15秒 + 10秒去重 | 67% ↓ |
  | status         | 5秒，不去重 | 15秒 + 10秒去重 | 67% ↓ |
  | positions      | 5秒，不去重 | 15秒 + 10秒去重 | 67% ↓ |
  | decisions      | 10秒    | 30秒 + 20秒去重 | 67% ↓ |
  | statistics     | 10秒    | 30秒 + 20秒去重 | 67% ↓ |
  | equity-history | 10秒    | 30秒 + 20秒去重 | 67% ↓ |
  | performance    | 10秒    | 30秒 + 20秒去重 | 67% ↓ |
  | competition    | 5秒     | 15秒 + 10秒去重 | 67% ↓ |

  新增配置：
  - revalidateOnFocus: false - 禁用页面聚焦时重新请求
  - dedupingInterval - 防止短时间内重复请求