### PR TITLE
1. 修复hyperliquid 总盈亏，总净值计算，持仓盈亏百分比错误问题

### DIFF
--- a/trader/auto_trader.go
+++ b/trader/auto_trader.go
@@ -427,14 +427,6 @@ func (at *AutoTrader) buildTradingContext() (*decision.Context, error) {
 		unrealizedPnl := pos["unRealizedProfit"].(float64)
 		liquidationPrice := pos["liquidationPrice"].(float64)
 
-		// 计算盈亏百分比
-		pnlPct := 0.0
-		if side == "long" {
-			pnlPct = ((markPrice - entryPrice) / entryPrice) * 100
-		} else {
-			pnlPct = ((entryPrice - markPrice) / entryPrice) * 100
-		}
-
 		// 计算占用保证金（估算）
 		leverage := 10 // 默认值，实际应该从持仓信息获取
 		if lev, ok := pos["leverage"].(float64); ok {
@@ -442,6 +434,14 @@ func (at *AutoTrader) buildTradingContext() (*decision.Context, error) {
 		}
 		marginUsed := (quantity * markPrice) / float64(leverage)
 		totalMarginUsed += marginUsed
+
+		// 计算盈亏百分比
+		pnlPct := 0.0
+		if side == "long" {
+			pnlPct = ((markPrice - entryPrice) / entryPrice) * float64(leverage) * 100
+		} else {
+			pnlPct = ((entryPrice - markPrice) / entryPrice) * float64(leverage) * 100
+		}
 
 		// 跟踪持仓首次出现时间
 		posKey := symbol + "_" + side
@@ -873,9 +873,9 @@ func (at *AutoTrader) GetPositions() ([]map[string]interface{}, error) {
 
 		pnlPct := 0.0
 		if side == "long" {
-			pnlPct = ((markPrice - entryPrice) / entryPrice) * 100
+			pnlPct = ((markPrice - entryPrice) / entryPrice) * float64(leverage) * 100
 		} else {
-			pnlPct = ((entryPrice - markPrice) / entryPrice) * 100
+			pnlPct = ((entryPrice - markPrice) / entryPrice) * float64(leverage) * 100
 		}
 
 		marginUsed := (quantity * markPrice) / float64(leverage)

--- a/trader/hyperliquid_trader.go
+++ b/trader/hyperliquid_trader.go
@@ -85,12 +85,12 @@ func (t *HyperliquidTrader) GetBalance() (map[string]interface{}, error) {
 	result := make(map[string]interface{})
 
 	// 🔍 调试：打印API返回的完整CrossMarginSummary结构
-	summaryJSON, _ := json.MarshalIndent(accountState.CrossMarginSummary, "  ", "  ")
+	summaryJSON, _ := json.MarshalIndent(accountState.MarginSummary, "  ", "  ")
 	log.Printf("🔍 [DEBUG] Hyperliquid API CrossMarginSummary完整数据:")
 	log.Printf("%s", string(summaryJSON))
 
-	accountValue, _ := strconv.ParseFloat(accountState.CrossMarginSummary.AccountValue, 64)
-	totalMarginUsed, _ := strconv.ParseFloat(accountState.CrossMarginSummary.TotalMarginUsed, 64)
+	accountValue, _ := strconv.ParseFloat(accountState.MarginSummary.AccountValue, 64)
+	totalMarginUsed, _ := strconv.ParseFloat(accountState.MarginSummary.TotalMarginUsed, 64)
 
 	// ⚠️ 关键修复：从所有持仓中累加真正的未实现盈亏
 	totalUnrealizedPnl := 0.0


### PR DESCRIPTION
1. 修复hyperliquid 总盈亏，总净值计算错误问题
2. 修复持仓盈亏百分比错误，计算公式应该加入杠杆倍数