### PR TITLE
fix: host not found in upstream "nofx"

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -28,7 +28,7 @@ server {
 
     # Proxy API requests to backend (preserves /api/ path, with timeouts)
     location /api/ {
-        proxy_pass http://nofx:8080/api/;
+        proxy_pass http://nofx-trading:8080/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
修复 nginx 配置报错问题 `nginx: [emerg] host not found in upstream "nofx" in /etc/nginx/conf.d/default.conf:31`
```
nofx-frontend  | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
nofx-frontend  | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
nofx-frontend  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
nofx-frontend  | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
nofx-frontend  | 10-listen-on-ipv6-by-default.sh: info: /etc/nginx/conf.d/default.conf differs from the packaged version
nofx-frontend  | /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
nofx-frontend  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
nofx-frontend  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
nofx-frontend  | /docker-entrypoint.sh: Configuration complete; ready for start up
nofx-frontend  | 2025/10/30 15:57:00 [emerg] 1#1: host not found in upstream "nofx" in /etc/nginx/conf.d/default.conf:31
nofx-frontend  | nginx: [emerg] host not found in upstream "nofx" in /etc/nginx/conf.d/default.conf:31
nofx-frontend  | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
nofx-frontend  | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
nofx-frontend  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
nofx-frontend  | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
nofx-frontend  | 10-listen-on-ipv6-by-default.sh: info: /etc/nginx/conf.d/default.conf differs from the packaged version
```