### PR TITLE
ci(docker): 添加Docker镜像构建和推送的GitHub Actions工作流

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -72,7 +72,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}
             type=raw,value=latest,enable={{is_default_branch}}
       
       - name: Build and push ${{ matrix.name }} image


### PR DESCRIPTION
支持在main和dev分支及版本标签的push事件触发
支持Pull Request事件及手动触发工作流
配置了backend和frontend两个镜像的构建策略
使用QEMU和Docker Buildx实现多平台构建（amd64和arm64）
集成GitHub Container Registry和Docker Hub登录
自动生成镜像元数据和多标签支持
支持基于GitHub Actions缓存提升构建速度
实现根据事件类型自动决定是否推送镜像
输出构建完成的镜像摘要信息