### PR TITLE
Add 'enabled' field to trader configuration

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -430,6 +430,7 @@ cp config.json.example config.json
     {
       "id": "my_trader",
       "name": "我的AI交易员",
+      "enabled": true,
       "ai_model": "deepseek",
       "binance_api_key": "YOUR_BINANCE_API_KEY",
       "binance_secret_key": "YOUR_BINANCE_SECRET_KEY",


### PR DESCRIPTION
使用推荐配置内容后报错，日志信息： ❌ 没有启用的trader，请在config.json中设置至少一个trader的enabled=true