### PR TITLE
Fix broken DashScope link in README files (fixes #128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Before configuring the system, you need to obtain AI API keys. Choose one of the
 
 **How to get Qwen API Key:**
 
-1. **Visit**: [https://dashscope.aliyuncs.com](https://dashscope.aliyuncs.com)
+1. **Visit**: [https://dashscope.console.aliyun.com](https://dashscope.console.aliyun.com)
 2. **Register**: Sign up with Alibaba Cloud account
 3. **Enable Service**: Activate DashScope service
 4. **Create API Key**:
@@ -1271,7 +1271,7 @@ We welcome contributions from the community! See our comprehensive guides:
 
 - [Binance API](https://binance-docs.github.io/apidocs/futures/en/) - Binance Futures API
 - [DeepSeek](https://platform.deepseek.com/) - DeepSeek AI API
-- [Qwen](https://dashscope.aliyuncs.com/) - Alibaba Cloud Qwen
+- [Qwen](https://dashscope.console.aliyun.com/) - Alibaba Cloud Qwen
 - [TA-Lib](https://ta-lib.org/) - Technical indicator library
 - [Recharts](https://recharts.org/) - React chart library
 

--- a/docs/i18n/ru/README.md
+++ b/docs/i18n/ru/README.md
@@ -399,7 +399,7 @@ cd ..
 
 **Как получить Qwen API ключ:**
 
-1. **Посетите**: [https://dashscope.aliyuncs.com](https://dashscope.aliyuncs.com)
+1. **Посетите**: [https://dashscope.console.aliyun.com](https://dashscope.console.aliyun.com)
 2. **Зарегистрируйтесь**: Используя аккаунт Alibaba Cloud
 3. **Активируйте сервис**: Активируйте DashScope сервис
 4. **Создайте API ключ**:
@@ -1094,7 +1094,7 @@ sudo apt-get install libta-lib0-dev
 
 - [Binance API](https://binance-docs.github.io/apidocs/futures/en/) - Binance Futures API
 - [DeepSeek](https://platform.deepseek.com/) - DeepSeek AI API
-- [Qwen](https://dashscope.aliyuncs.com/) - Alibaba Cloud Qwen
+- [Qwen](https://dashscope.console.aliyun.com/) - Alibaba Cloud Qwen
 - [TA-Lib](https://ta-lib.org/) - Библиотека технических индикаторов
 - [Recharts](https://recharts.org/) - Библиотека графиков React
 

--- a/docs/i18n/uk/README.md
+++ b/docs/i18n/uk/README.md
@@ -402,7 +402,7 @@ cd ..
 
 **Як отримати Qwen API ключ:**
 
-1. **Відвідайте**: [https://dashscope.aliyuncs.com](https://dashscope.aliyuncs.com)
+1. **Відвідайте**: [https://dashscope.console.aliyun.com](https://dashscope.console.aliyun.com)
 2. **Зареєструйтеся**: Використовуючи акаунт Alibaba Cloud
 3. **Активуйте сервіс**: Активуйте DashScope сервіс
 4. **Створіть API ключ**:

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -398,7 +398,7 @@ cd ..
 
 **如何获取Qwen API密钥：**
 
-1. **访问**：[https://dashscope.aliyuncs.com](https://dashscope.aliyuncs.com)
+1. **访问**：[https://dashscope.console.aliyun.com](https://dashscope.console.aliyun.com)
 2. **注册**：使用阿里云账户注册
 3. **开通服务**：激活DashScope服务
 4. **创建API密钥**：
@@ -1290,7 +1290,7 @@ MIT License - 详见 [LICENSE](LICENSE) 文件
 
 - [Binance API](https://binance-docs.github.io/apidocs/futures/cn/) - 币安合约API
 - [DeepSeek](https://platform.deepseek.com/) - DeepSeek AI API
-- [Qwen](https://dashscope.aliyuncs.com/) - 阿里云通义千问
+- [Qwen](https://dashscope.console.aliyun.com/) - 阿里云通义千问
 - [TA-Lib](https://ta-lib.org/) - 技术指标库
 - [Recharts](https://recharts.org/) - React图表库
 


### PR DESCRIPTION
- Updated DashScope URL from https://dashscope.aliyuncs.com to https://dashscope.console.aliyun.com
- Fixed in all README files: README.md, README.zh-CN.md, README.uk.md, README.ru.md
- This resolves the 404 error reported in issue #128