### PR TITLE
fix: Model validation error when saving AI model configuration

### DIFF
--- a/web/src/components/AITradersPage.tsx
+++ b/web/src/components/AITradersPage.tsx
@@ -277,16 +277,16 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
 
   const handleSaveModelConfig = async (modelId: string, apiKey: string, customApiUrl?: string, customModelName?: string) => {
     try {
-      // 找到要配置的模型（从supportedModels中）
-      const modelToUpdate = supportedModels?.find(m => m.id === modelId);
+      // 创建或更新用户的模型配置
+      const existingModel = allModels?.find(m => m.id === modelId);
+      let updatedModels;
+
+      // 找到要配置的模型（优先从已配置列表，其次从支持列表）
+      const modelToUpdate = existingModel || supportedModels?.find(m => m.id === modelId);
       if (!modelToUpdate) {
         alert(t('modelNotExist', language));
         return;
       }
-
-      // 创建或更新用户的模型配置
-      const existingModel = allModels?.find(m => m.id === modelId);
-      let updatedModels;
 
       if (existingModel) {
         // 更新现有配置


### PR DESCRIPTION
## Summary
This PR fixes the "模型不存在" (Model does not exist) error that occurs when users try to save an existing AI model configuration.

## Issue
Fixes #245

## Root Cause
The `handleSaveModelConfig` function in `AITradersPage.tsx` was validating the model ID only against `supportedModels`, which caused the validation to fail when:
- Users edit an existing model configuration
- The model ID format is `{user_id}_{provider}` (e.g., `admin_deepseek`)
- This ID doesn't exist in `supportedModels` which uses format `{provider}` (e.g., `deepseek`)

## Changes
- **Code Fix**: Updated validation logic in `handleSaveModelConfig` (line 278-289)
- **Testing**: Merged PR #229's test infrastructure and added 4 unit tests for Issue #245
- Now checks `allModels` (user's configured models) first, then falls back to `supportedModels`
- Reordered code to check for existing model before validation

## Before
```typescript
const modelToUpdate = supportedModels?.find(m => m.id === modelId);
if (!modelToUpdate) {
  alert(t('modelNotExist', language));
  return;
}

const existingModel = allModels?.find(m => m.id === modelId);
```

## After
```typescript
const existingModel = allModels?.find(m => m.id === modelId);
let updatedModels;

const modelToUpdate = existingModel || supportedModels?.find(m => m.id === modelId);
if (!modelToUpdate) {
  alert(t('modelNotExist', language));
  return;
}
```

## Testing
- ✅ **8 unit tests passing** (4 for #227 + 4 for #245)
- ✅ Test: Existing user models can be edited without error
- ✅ Test: Validation checks allModels before supportedModels
- ✅ Test: New models still validate against supportedModels
- ✅ Manually tested: Can now save existing AI model configurations

## Test Results
```bash
$ npm test -- AITradersPage.test.tsx
✓ src/components/AITradersPage.test.tsx (8 tests) 233ms
  Test Files  1 passed (1)
       Tests  8 passed (8)
```

## Related
- This PR is separate from PR #229, which fixes a similar issue in the trader editing workflow
- PR #229 updates `handleSaveEditTrader` while this PR fixes `handleSaveModelConfig`
- This PR merges PR #229's test infrastructure to maintain consistency

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>