### PR TITLE
fix: Correct 4h kline data storage in WebSocket monitor

### DIFF
--- a/market/monitor.go
+++ b/market/monitor.go
@@ -106,8 +106,8 @@ func (m *WSMonitor) initializeHistoricalData() error {
 				return
 			}
 			if len(klines4h) > 0 {
-				m.klineDataMap4h.Store(s, klines)
-				log.Printf("已加载 %s 的历史K线数据-4h: %d 条", s, len(klines))
+				m.klineDataMap4h.Store(s, klines4h)
+				log.Printf("已加载 %s 的历史K线数据-4h: %d 条", s, len(klines4h))
 			}
 		}(symbol)
 	}


### PR DESCRIPTION
## 问题描述 / Problem Description

修复了 WebSocket 监控器初始化时的关键 bug，4小时 K线数据被错误地存储为 3分钟 K线数据。

Fixed a critical bug in WebSocket monitor initialization where 4h kline data was incorrectly stored with 3m kline data.

---

## Bug 详情 / Bug Details

**位置 / Location**: `market/monitor.go:109-110`

**错误代码 / Bug**:
```go
if len(klines4h) > 0 {
    m.klineDataMap4h.Store(s, klines)  // ❌ 应该是 klines4h
    log.Printf("已加载 %s 的历史K线数据-4h: %d 条", s, len(klines))  // ❌ 应该是 len(klines4h)
}
```

**修复后 / Fixed**:
```go
if len(klines4h) > 0 {
    m.klineDataMap4h.Store(s, klines4h)  // ✅ 正确
    log.Printf("已加载 %s 的历史K线数据-4h: %d 条", s, len(klines4h))  // ✅ 正确
}
```

---

## 影响 / Impact

### 修复前 / Before Fix

```
获取 BTCUSDT 4h K线 → 实际返回 3m K线数据
     ↓
技术指标计算错误
     ↓
AI 决策基于错误数据
```

**严重性**: 🔴 Critical - 导致所有 4小时 K线查询返回错误数据

### 修复后 / After Fix

```
获取 BTCUSDT 4h K线 → 正确返回 4h K线数据
     ↓
技术指标计算正确
     ↓
AI 决策基于正确数据
```

---

## 测试 / Testing

### 验证步骤 / Verification Steps

1. 启动 WebSocket 监控器
2. 检查日志输出是否正确显示 4h K线数量
3. 调用 `market.Get(symbol)` 验证返回的 4h K线数据正确

### 预期结果 / Expected Results

- ✅ `klineDataMap4h` 存储正确的 4小时 K线数据
- ✅ 日志正确显示 4h K线数量
- ✅ 技术指标基于正确周期的数据计算

---

## 变更内容 / Changes

- 修改 `market/monitor.go:109` - 使用 `klines4h` 而不是 `klines`
- 修改 `market/monitor.go:110` - 日志使用 `len(klines4h)`

---

## 相关 Issue / Related Issues

- Fixes #260 (WebSocket K-line monitor follow-up improvements)
- Related #176 (Kline获取方式为Websocket缓存)

---

## Checklist

- [x] 代码已测试 / Code tested
- [x] 修复了 critical bug
- [x] 没有引入新的依赖
- [x] commit 消息符合规范