### PR TITLE
fix(ci): Add comprehensive permissions to pr-checks workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,11 +7,18 @@ on:
       - dev
       - main
 
+# Default permissions for all jobs (can be overridden per job)
+permissions:
+  contents: read           # Read repository contents
+  pull-requests: write     # Manage PRs (labels, comments)
+  issues: write           # Manage issues (PRs are issues)
+
 jobs:
   # Validate PR title and description
   validate-pr:
     name: Validate PR Format
     runs-on: ubuntu-latest
+    # Inherits workflow-level permissions (contents: read, pull-requests: write, issues: write)
     steps:
       - name: Check PR title format
         uses: amannn/action-semantic-pull-request@v5
@@ -86,6 +93,8 @@ jobs:
   backend-tests:
     name: Backend Tests (Go)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read      # Only need read access for testing
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -138,6 +147,8 @@ jobs:
   frontend-tests:
     name: Frontend Tests (React/TypeScript)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read      # Only need read access for testing
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -176,7 +187,9 @@ jobs:
     name: Auto Label PR
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
+      issues: write          # Required: PRs are issues, labeler needs to modify issue labels
     steps:
       - uses: actions/labeler@v5
         with:
@@ -187,6 +200,9 @@ jobs:
   security-check:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # Required: Upload SARIF results to GitHub Security
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -209,6 +225,8 @@ jobs:
   secrets-check:
     name: Check for Secrets
     runs-on: ubuntu-latest
+    permissions:
+      contents: read      # Only need read access for scanning
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -226,6 +244,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate-pr, backend-tests, frontend-tests, security-check, secrets-check]
     if: always()
+    permissions:
+      contents: read      # Only need read access for status checking
     steps:
       - name: Check all jobs
         run: |


### PR DESCRIPTION
# Pull Request

## 📝 Description

<!-- Provide a brief summary of your changes -->

## 🎯 Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] 🔧 Build/config change

Add workflow-level default permissions and explicit per-job permissions following the principle of least privilege:

Workflow-level (default):
- contents: read - Read repository contents
- pull-requests: write - Manage PR labels and comments
- issues: write - Manage issues (PRs are issues in GitHub API)

Job-level overrides:
- validate-pr: Inherits workflow defaults (needs issue/PR write access)
- backend-tests: Downgrade to read-only (no write operations needed)
- frontend-tests: Downgrade to read-only (no write operations needed)
- auto-label: Add missing issues:write (labeler operates on PR issues)
- security-check: Add security-events:write (upload SARIF results)
- secrets-check: Downgrade to read-only (scanning only)
- all-checks: Downgrade to read-only (status checking only)

This fixes:
1. Potential 403 errors when auto-label tries to add labels to PR issues
2. Missing permission for uploading security scan results
3. Overly permissive access for read-only jobs

Related: #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)
