### PR TITLE
feat(multi-account): support multiple accounts for same exchange type

### DIFF
--- a/manager/trader_manager.go
+++ b/manager/trader_manager.go
@@ -14,6 +14,19 @@ import (
 	"time"
 )
 
+// extractExchangeType 从ID中提取交易所类型（如 binance_子账户1 → binance）
+func extractExchangeType(id string) string {
+	// 支持的交易所类型
+	types := []string{"binance", "hyperliquid", "aster", "okx", "bybit"}
+	idLower := strings.ToLower(id)
+	for _, typ := range types {
+		if strings.HasPrefix(idLower, typ) {
+			return typ
+		}
+	}
+	return "binance" // 默认
+}
+
 // CompetitionCache 竞赛数据缓存
 type CompetitionCache struct {
 	data      map[string]interface{}
@@ -241,14 +254,15 @@ func (tm *TraderManager) addTraderFromDB(traderCfg *config.TraderRecord, aiModel
 		SystemPromptTemplate:  traderCfg.SystemPromptTemplate, // 系统提示词模板
 	}
 
-	// 根据交易所类型设置API密钥
-	if exchangeCfg.ID == "binance" {
+	// 根据交易所类型设置API密钥（支持自定义ID如 binance_子账户1）
+	exchangeType := extractExchangeType(exchangeCfg.ID)
+	if exchangeType == "binance" {
 		traderConfig.BinanceAPIKey = exchangeCfg.APIKey
 		traderConfig.BinanceSecretKey = exchangeCfg.SecretKey
-	} else if exchangeCfg.ID == "hyperliquid" {
+	} else if exchangeType == "hyperliquid" {
 		traderConfig.HyperliquidPrivateKey = exchangeCfg.APIKey // hyperliquid用APIKey存储private key
 		traderConfig.HyperliquidWalletAddr = exchangeCfg.HyperliquidWalletAddr
-	} else if exchangeCfg.ID == "aster" {
+	} else if exchangeType == "aster" {
 		traderConfig.AsterUser = exchangeCfg.AsterUser
 		traderConfig.AsterSigner = exchangeCfg.AsterSigner
 		traderConfig.AsterPrivateKey = exchangeCfg.AsterPrivateKey
@@ -347,14 +361,15 @@ func (tm *TraderManager) AddTraderFromDB(traderCfg *config.TraderRecord, aiModel
 		TradingCoins:          tradingCoins,
 	}
 
-	// 根据交易所类型设置API密钥
-	if exchangeCfg.ID == "binance" {
+	// 根据交易所类型设置API密钥（支持自定义ID如 binance_子账户1）
+	exchangeType := extractExchangeType(exchangeCfg.ID)
+	if exchangeType == "binance" {
 		traderConfig.BinanceAPIKey = exchangeCfg.APIKey
 		traderConfig.BinanceSecretKey = exchangeCfg.SecretKey
-	} else if exchangeCfg.ID == "hyperliquid" {
+	} else if exchangeType == "hyperliquid" {
 		traderConfig.HyperliquidPrivateKey = exchangeCfg.APIKey // hyperliquid用APIKey存储private key
 		traderConfig.HyperliquidWalletAddr = exchangeCfg.HyperliquidWalletAddr
-	} else if exchangeCfg.ID == "aster" {
+	} else if exchangeType == "aster" {
 		traderConfig.AsterUser = exchangeCfg.AsterUser
 		traderConfig.AsterSigner = exchangeCfg.AsterSigner
 		traderConfig.AsterPrivateKey = exchangeCfg.AsterPrivateKey
@@ -891,14 +906,15 @@ func (tm *TraderManager) loadSingleTrader(traderCfg *config.TraderRecord, aiMode
 		SystemPromptTemplate: traderCfg.SystemPromptTemplate, // 系统提示词模板
 	}
 
-	// 根据交易所类型设置API密钥
-	if exchangeCfg.ID == "binance" {
+	// 根据交易所类型设置API密钥（支持自定义ID如 binance_子账户1）
+	exchangeType := extractExchangeType(exchangeCfg.ID)
+	if exchangeType == "binance" {
 		traderConfig.BinanceAPIKey = exchangeCfg.APIKey
 		traderConfig.BinanceSecretKey = exchangeCfg.SecretKey
-	} else if exchangeCfg.ID == "hyperliquid" {
+	} else if exchangeType == "hyperliquid" {
 		traderConfig.HyperliquidPrivateKey = exchangeCfg.APIKey // hyperliquid用APIKey存储private key
 		traderConfig.HyperliquidWalletAddr = exchangeCfg.HyperliquidWalletAddr
-	} else if exchangeCfg.ID == "aster" {
+	} else if exchangeType == "aster" {
 		traderConfig.AsterUser = exchangeCfg.AsterUser
 		traderConfig.AsterSigner = exchangeCfg.AsterSigner
 		traderConfig.AsterPrivateKey = exchangeCfg.AsterPrivateKey

--- a/trader/auto_trader.go
+++ b/trader/auto_trader.go
@@ -13,6 +13,19 @@ import (
 	"time"
 )
 
+// extractExchangeType 从ID中提取交易所类型（如 binance_子账户1 → binance）
+func extractExchangeType(id string) string {
+	// 支持的交易所类型
+	types := []string{"binance", "hyperliquid", "aster", "okx", "bybit"}
+	idLower := strings.ToLower(id)
+	for _, typ := range types {
+		if strings.HasPrefix(idLower, typ) {
+			return typ
+		}
+	}
+	return "binance" // 默认
+}
+
 // AutoTraderConfig 自动交易配置（简化版 - AI全权决策）
 type AutoTraderConfig struct {
 	// Trader标识
@@ -163,7 +176,11 @@ func NewAutoTrader(config AutoTraderConfig) (*AutoTrader, error) {
 	}
 	log.Printf("📊 [%s] 仓位模式: %s", config.Name, marginModeStr)
 
-	switch config.Exchange {
+	// 从Exchange ID中提取基础类型（支持自定义ID如 binance_子账户1）
+	exchangeType := extractExchangeType(config.Exchange)
+	log.Printf("🔍 [%s] 交易所ID: %s, 提取类型: %s", config.Name, config.Exchange, exchangeType)
+
+	switch exchangeType {
 	case "binance":
 		log.Printf("🏦 [%s] 使用币安合约交易", config.Name)
 		trader = NewFuturesTrader(config.BinanceAPIKey, config.BinanceSecretKey)
@@ -180,7 +197,7 @@ func NewAutoTrader(config AutoTraderConfig) (*AutoTrader, error) {
 			return nil, fmt.Errorf("初始化Aster交易器失败: %w", err)
 		}
 	default:
-		return nil, fmt.Errorf("不支持的交易平台: %s", config.Exchange)
+		return nil, fmt.Errorf("不支持的交易平台: %s (提取类型: %s)", config.Exchange, exchangeType)
 	}
 
 	// 验证初始金额配置

--- a/web/src/components/TraderConfigModal.tsx
+++ b/web/src/components/TraderConfigModal.tsx
@@ -9,6 +9,16 @@ function getShortName(fullName: string): string {
   return parts.length > 1 ? parts[parts.length - 1] : fullName;
 }
 
+// 获取友好的交易所显示名称
+function getExchangeDisplayName(exchange: Exchange): string {
+  // 如果ID包含下划线，说明是自定义ID（如 binance_子账户1）
+  if (exchange.id.includes('_')) {
+    return exchange.id; // 显示完整ID
+  }
+  // 否则显示交易所名称
+  return exchange.name || exchange.id;
+}
+
 interface TraderConfigData {
   trader_id?: string;
   trader_name: string;
@@ -269,7 +279,7 @@ export function TraderConfigModal({
                   >
                     {availableExchanges.map(exchange => (
                       <option key={exchange.id} value={exchange.id}>
-                        {getShortName(exchange.name || exchange.id).toUpperCase()}
+                        {getExchangeDisplayName(exchange)}
                       </option>
                     ))}
                   </select>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -132,6 +132,14 @@ export const api = {
     if (!res.ok) throw new Error('更新模型配置失败');
   },
 
+  async deleteModel(modelId: string): Promise<void> {
+    const res = await fetch(`${API_BASE}/models/${modelId}`, {
+      method: 'DELETE',
+      headers: getAuthHeaders(),
+    });
+    if (!res.ok) throw new Error('删除AI模型失败');
+  },
+
   // 交易所配置接口
   async getExchangeConfigs(): Promise<Exchange[]> {
     const res = await fetch(`${API_BASE}/exchanges`, {
@@ -155,6 +163,14 @@ export const api = {
       body: JSON.stringify(request),
     });
     if (!res.ok) throw new Error('更新交易所配置失败');
+  },
+
+  async deleteExchange(exchangeId: string): Promise<void> {
+    const res = await fetch(`${API_BASE}/exchanges/${exchangeId}`, {
+      method: 'DELETE',
+      headers: getAuthHeaders(),
+    });
+    if (!res.ok) throw new Error('删除交易所失败');
   },
 
   // 获取系统状态（支持trader_id）


### PR DESCRIPTION
## 📝 Description | 描述

**English:**

Add support for configuring multiple accounts of the same exchange type (e.g., `binance_subaccount1`, `binance_subaccount2`) with intelligent ID generation and management. This allows users to configure unlimited accounts for the same exchange with independent API keys.

**中文：**

新增多账户支持功能，允许用户为同一交易所类型配置多个账户（如 `binance_子账户1`、`binance_子账户2`），每个账户使用独立的API密钥。支持智能ID生成、序号填补、冲突检测等功能。

---

## 🎯 Type of Change | 变更类型

- [ ] 🐛 Bug fix | 修复 Bug
- [x] ✨ New feature | 新功能
- [ ] 💥 Breaking change | 破坏性变更
- [ ] 📝 Documentation update | 文档更新
- [ ] 🎨 Code style update | 代码样式更新
- [ ] ♻️ Refactoring | 重构
- [ ] ⚡ Performance improvement | 性能优化
- [ ] ✅ Test update | 测试更新
- [ ] 🔧 Build/config change | 构建/配置变更
- [ ] 🔒 Security fix | 安全修复

---

## 🔗 Related Issues | 相关 Issue

- Related to user feedback on multi-account configuration needs
- 相关用户反馈的多账户配置需求

---

## 📋 Changes Made | 具体变更

**English:**

**Backend:**
- Add `extractExchangeType()` function to support extracting base type from custom IDs
- Modify `UpdateExchange()` to support custom ID formats like `binance_subaccount1`
- Add `DeleteExchange()` and `DeleteAIModel()` for real database deletion
- Add DELETE API routes: `/api/exchanges/:id` and `/api/models/:id`
- Fix `trader_manager.go` to recognize custom exchange IDs when setting API keys
- Fix `auto_trader.go` to extract exchange type from custom IDs
- Fix `initDefaultData()` exchange type field (cex/dex instead of exchange name)

**Frontend:**
- Add `deleteModel()` and `deleteExchange()` API methods
- Update delete logic to use DELETE API instead of disable flag
- Add custom ID input with auto-generation logic
- Implement smart sequence filling algorithm (auto-fill gaps after deletion)
- Add real-time ID conflict detection with visual warnings
- Fix `TraderConfigModal` to display full exchange IDs
- Fix `CommunitySection` TypeScript interface definition

**中文：**

**后端：**
- 添加 `extractExchangeType()` 函数，支持从自定义ID提取基础类型
- 修改 `UpdateExchange()` 支持 `binance_子账户1` 等自定义ID格式
- 添加 `DeleteExchange()` 和 `DeleteAIModel()` 实现真正的数据库删除
- 添加 DELETE API 路由：`/api/exchanges/:id` 和 `/api/models/:id`
- 修复 `trader_manager.go` 识别自定义交易所ID并正确设置API密钥
- 修复 `auto_trader.go` 从自定义ID提取交易所类型
- 修复 `initDefaultData()` 交易所类型字段（cex/dex而非交易所名称）

**前端：**
- 添加 `deleteModel()` 和 `deleteExchange()` API方法
- 修改删除逻辑使用DELETE API而非禁用标志
- 添加自定义ID输入和自动生成功能
- 实现智能序号填补算法（删除后自动填补空缺）
- 添加实时ID冲突检测和视觉警告
- 修复 `TraderConfigModal` 显示完整交易所ID
- 修复 `CommunitySection` TypeScript接口定义

---

## 🧪 Testing | 测试

### Manual Testing | 手动测试

- [x] Tested locally | 本地测试通过
- [x] Tested on testnet | 测试网测试通过（交易所集成相关）
- [x] Tested with different configurations | 测试了不同配置
- [x] Verified no existing functionality broke | 确认没有破坏现有功能

### Test Environment | 测试环境

- **OS | 操作系统:** Windows 10
- **Go Version | Go 版本:** 1.21+
- **Node Version | Node 版本:** 20.x
- **Deployment | 部署方式:** Docker Compose
- **Exchange | 交易所:** Binance Futures

### Test Results | 测试结果

**Tested Scenarios | 测试场景:**

1. ✅ Create multiple Binance accounts (`binance_子账户1`, `binance_子账户2`, etc.)
2. ✅ Custom ID generation and auto-suggestion
3. ✅ Smart sequence filling (delete `子账户1`, next creation fills gap with `子账户1`)
4. ✅ ID conflict detection with red border warning
5. ✅ Real deletion from database (DELETE API)
6. ✅ API key correctly passed to trader with custom IDs
7. ✅ Backward compatible with existing `binance` configurations
8. ✅ Works with all exchange types (Binance, Hyperliquid, Aster)

**测试场景：**

1. ✅ 创建多个Binance账户（`binance_子账户1`、`binance_子账户2`等）
2. ✅ 自定义ID生成和自动建议
3. ✅ 智能序号填补（删除`子账户1`后，下次创建自动填补为`子账户1`）
4. ✅ ID冲突检测和红色边框警告
5. ✅ 真正从数据库删除（DELETE API）
6. ✅ 自定义ID的API密钥正确传递到交易器
7. ✅ 后向兼容现有`binance`等配置
8. ✅ 适用于所有交易所类型（Binance、Hyperliquid、Aster）

---

## 📸 Screenshots / Demo | 截图/演示

**功能演示 | Feature Demo:**

- 自定义ID输入界面，显示自动生成的建议ID
- 多个相同类型交易所配置并存
- ID冲突检测的视觉警告

---

## ✅ Checklist | 检查清单

### Code Quality | 代码质量

- [x] My code follows the project's code style | 我的代码遵循项目代码风格
- [x] I have performed a self-review of my code | 我已进行代码自查
- [x] I have commented my code, particularly in hard-to-understand areas | 我已添加代码注释
- [x] My changes generate no new warnings or errors | 我的变更没有产生新的警告或错误
- [x] Code compiles successfully | 代码编译成功
- [x] I have run `go fmt` (for Go code) | 我已运行 `go fmt`
- [ ] I have run `npm run lint` (for frontend code) | 我已运行 `npm run lint`

### Testing | 测试

- [ ] I have added tests that prove my fix is effective or that my feature works | 我已添加测试
- [ ] New and existing unit tests pass locally | 单元测试在本地通过
- [x] I have tested on testnet (for trading/exchange changes) | 我已在测试网测试
- [x] Integration tests pass | 集成测试通过

### Documentation | 文档

- [x] I have updated the documentation accordingly | 我已相应更新文档
- [ ] I have updated the README if needed | 我已更新 README
- [x] I have added inline code comments where necessary | 我已添加必要的代码注释
- [x] I have updated type definitions (for TypeScript changes) | 我已更新类型定义
- [ ] I have updated API documentation (if applicable) | 我已更新 API 文档

### Git

- [x] My commits follow the conventional commits format | 我的提交遵循 Conventional Commits 格式
- [x] I have rebased my branch on the latest `dev` branch | 我已将分支 rebase 到最新的 `dev` 分支
- [x] There are no merge conflicts | 没有合并冲突
- [x] Commit messages are clear and descriptive | 提交信息清晰明确

---

## 🔒 Security Considerations | 安全考虑

- [x] No API keys or secrets are hardcoded | 没有硬编码 API 密钥或密钥
- [x] User inputs are properly validated | 用户输入已正确验证
- [x] No SQL injection vulnerabilities introduced | 未引入 SQL 注入漏洞
- [x] No XSS vulnerabilities introduced | 未引入 XSS 漏洞
- [x] Authentication/authorization properly handled | 认证/授权已正确处理
- [x] Sensitive data is encrypted | 敏感数据已加密

---

## ⚡ Performance Impact | 性能影响

- [x] No significant performance impact | 无显著性能影响

**English:**

The changes only affect configuration loading logic, with minimal performance overhead.

**中文：**

改动仅影响配置加载逻辑，性能开销极小。

---

## 🌐 Internationalization | 国际化

- [x] All user-facing text supports i18n | 所有面向用户的文本支持国际化
- [x] Both English and Chinese versions provided | 提供了中英文版本

---

## 📚 Additional Notes | 补充说明

**English:**

This feature also applies to AI model configurations, allowing multiple configs for the same provider (e.g., multiple DeepSeek configs with different API keys).

The implementation uses a consistent `extractExchangeType()` function across database, API, manager, and trader layers to ensure proper handling of custom IDs.

**中文：**

此功能同样适用于AI模型配置，允许为同一provider配置多个实例（如多个DeepSeek配置使用不同的API密钥）。

实现在数据库层、API层、管理器层和交易器层使用统一的 `extractExchangeType()` 函数，确保正确处理自定义ID。

---

## 🎯 Review Focus Areas | 审查重点

Please pay special attention to:

请特别注意：

- [x] Logic changes | 逻辑变更
- [x] Security implications | 安全影响
- [ ] Performance optimization | 性能优化
- [x] API changes | API 变更
- [x] Database schema changes | 数据库架构变更
- [x] UI/UX changes | UI/UX 变更

**Specific areas | 具体区域:**
- ID extraction logic in multiple layers
- API key assignment logic in trader_manager
- DELETE API security checks
- 多层中的ID提取逻辑
- trader_manager中的API密钥分配逻辑
- DELETE API的安全检查

---

**By submitting this PR, I confirm that:**

**提交此 PR，我确认：**

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) | 我已阅读贡献指南
- [x] I agree to the [Code of Conduct](../CODE_OF_CONDUCT.md) | 我同意行为准则
- [x] My contribution is licensed under the MIT License | 我的贡献遵循 MIT 许可证
- [x] I understand this is a voluntary contribution | 我理解这是自愿贡献
- [x] I have the right to submit this code | 我有权提交此代码

---

## 📋 PR Size Estimate | PR 大小估计

- [ ] 🟢 Small (< 100 lines) | 小（< 100 行）
- [x] 🟡 Medium (100-500 lines) | 中（100-500 行）
- [ ] 🔴 Large (> 500 lines) | 大（> 500 行）

**Stats | 统计:** 8 files changed, 454 insertions(+), 239 deletions(-)