### PR TITLE
 fix: resolve login redirect loop issue (#422)

### DIFF
--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -130,30 +130,30 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ user_id: userID, otp_code: otpCode }),
-      });
+      })
 
-      const data = await response.json();
+      const data = await response.json()
 
       if (response.ok) {
         // 登录成功，保存token和用户信息
-        const userInfo = { id: data.user_id, email: data.email };
-        setToken(data.token);
-        setUser(userInfo);
-        localStorage.setItem('auth_token', data.token);
-        localStorage.setItem('auth_user', JSON.stringify(userInfo));
-        
-        // 跳转到首页
-        window.history.pushState({}, '', '/');
-        window.dispatchEvent(new PopStateEvent('popstate'));
-        
-        return { success: true, message: data.message };
+        const userInfo = { id: data.user_id, email: data.email }
+        setToken(data.token)
+        setUser(userInfo)
+        localStorage.setItem('auth_token', data.token)
+        localStorage.setItem('auth_user', JSON.stringify(userInfo))
+
+        // 跳转到配置页面
+        window.history.pushState({}, '', '/traders')
+        window.dispatchEvent(new PopStateEvent('popstate'))
+
+        return { success: true, message: data.message }
       } else {
-        return { success: false, message: data.error };
+        return { success: false, message: data.error }
       }
     } catch (error) {
-      return { success: false, message: 'OTP验证失败，请重试' };
+      return { success: false, message: 'OTP验证失败，请重试' }
     }
-  };
+  }
 
   const completeRegistration = async (userID: string, otpCode: string) => {
     try {
@@ -163,30 +163,30 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ user_id: userID, otp_code: otpCode }),
-      });
+      })
 
-      const data = await response.json();
+      const data = await response.json()
 
       if (response.ok) {
         // 注册完成，自动登录
-        const userInfo = { id: data.user_id, email: data.email };
-        setToken(data.token);
-        setUser(userInfo);
-        localStorage.setItem('auth_token', data.token);
-        localStorage.setItem('auth_user', JSON.stringify(userInfo));
-        
-        // 跳转到首页
-        window.history.pushState({}, '', '/');
-        window.dispatchEvent(new PopStateEvent('popstate'));
-        
-        return { success: true, message: data.message };
+        const userInfo = { id: data.user_id, email: data.email }
+        setToken(data.token)
+        setUser(userInfo)
+        localStorage.setItem('auth_token', data.token)
+        localStorage.setItem('auth_user', JSON.stringify(userInfo))
+
+        // 跳转到配置页面
+        window.history.pushState({}, '', '/traders')
+        window.dispatchEvent(new PopStateEvent('popstate'))
+
+        return { success: true, message: data.message }
       } else {
-        return { success: false, message: data.error };
+        return { success: false, message: data.error }
       }
     } catch (error) {
-      return { success: false, message: '注册完成失败，请重试' };
+      return { success: false, message: '注册完成失败，请重试' }
     }
-  };
+  }
 
   const logout = () => {
     setUser(null);

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -23,57 +23,114 @@ export function LandingPage() {
   console.log('LandingPage - user:', user, 'isLoggedIn:', isLoggedIn);
   return (
     <>
-      <HeaderBar 
-        onLoginClick={() => setShowLoginModal(true)} 
-        isLoggedIn={isLoggedIn} 
+      <HeaderBar
+        onLoginClick={() => setShowLoginModal(true)}
+        isLoggedIn={isLoggedIn}
         isHomePage={true}
         language={language}
         onLanguageChange={setLanguage}
         user={user}
         onLogout={logout}
         onPageChange={(page) => {
-          console.log('LandingPage onPageChange called with:', page);
+          console.log('LandingPage onPageChange called with:', page)
           if (page === 'competition') {
-            window.location.href = '/competition';
+            window.location.href = '/competition'
           } else if (page === 'traders') {
-            window.location.href = '/traders';
+            window.location.href = '/traders'
           } else if (page === 'trader') {
-            window.location.href = '/dashboard';
+            window.location.href = '/dashboard'
           }
         }}
       />
-      <div className='min-h-screen px-4 sm:px-6 lg:px-8' style={{ background: 'var(--brand-black)', color: 'var(--brand-light-gray)' }}>
-      <HeroSection language={language} />
-      <AboutSection language={language} />
-      <FeaturesSection language={language} />
-      <HowItWorksSection language={language} />
-      <CommunitySection />
+      <div
+        className='min-h-screen px-4 sm:px-6 lg:px-8'
+        style={{
+          background: 'var(--brand-black)',
+          color: 'var(--brand-light-gray)',
+        }}
+      >
+        <HeroSection language={language} />
+        <AboutSection language={language} />
+        <FeaturesSection language={language} />
+        <HowItWorksSection language={language} />
+        <CommunitySection />
 
-      {/* CTA */}
-      <AnimatedSection backgroundColor='var(--panel-bg)'>
-        <div className='max-w-4xl mx-auto text-center'>
-          <motion.h2 className='text-5xl font-bold mb-6' style={{ color: 'var(--brand-light-gray)' }} initial={{ opacity: 0, y: 30 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }}>
-            {t('readyToDefine', language)}
-          </motion.h2>
-          <motion.p className='text-xl mb-12' style={{ color: 'var(--text-secondary)' }} initial={{ opacity: 0, y: 30 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ delay: 0.1 }}>
-            {t('startWithCrypto', language)}
-          </motion.p>
-          <div className='flex flex-wrap justify-center gap-4'>
-            <motion.button onClick={() => setShowLoginModal(true)} className='flex items-center gap-2 px-10 py-4 rounded-lg font-semibold text-lg' style={{ background: 'var(--brand-yellow)', color: 'var(--brand-black)' }} whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-              {t('getStartedNow', language)}
-              <motion.div animate={{ x: [0, 5, 0] }} transition={{ duration: 1.5, repeat: Infinity }}>
-                <ArrowRight className='w-5 h-5' />
-              </motion.div>
-            </motion.button>
-            <motion.a href='https://github.com/tinkle-community/nofx/tree/dev' target='_blank' rel='noopener noreferrer' className='flex items-center gap-2 px-10 py-4 rounded-lg font-semibold text-lg' style={{ background: 'transparent', color: 'var(--brand-light-gray)', border: '2px solid var(--brand-yellow)' }} whileHover={{ scale: 1.05, backgroundColor: 'rgba(240, 185, 11, 0.1)' }} whileTap={{ scale: 0.95 }}>
-              {t('viewSourceCode', language)}
-            </motion.a>
+        {/* CTA */}
+        <AnimatedSection backgroundColor='var(--panel-bg)'>
+          <div className='max-w-4xl mx-auto text-center'>
+            <motion.h2
+              className='text-5xl font-bold mb-6'
+              style={{ color: 'var(--brand-light-gray)' }}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+            >
+              {t('readyToDefine', language)}
+            </motion.h2>
+            <motion.p
+              className='text-xl mb-12'
+              style={{ color: 'var(--text-secondary)' }}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: 0.1 }}
+            >
+              {t('startWithCrypto', language)}
+            </motion.p>
+            <div className='flex flex-wrap justify-center gap-4'>
+              <motion.button
+                onClick={() => {
+                  if (isLoggedIn) {
+                    window.location.href = '/traders'
+                  } else {
+                    setShowLoginModal(true)
+                  }
+                }}
+                className='flex items-center gap-2 px-10 py-4 rounded-lg font-semibold text-lg'
+                style={{
+                  background: 'var(--brand-yellow)',
+                  color: 'var(--brand-black)',
+                }}
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.95 }}
+              >
+                {t('getStartedNow', language)}
+                <motion.div
+                  animate={{ x: [0, 5, 0] }}
+                  transition={{ duration: 1.5, repeat: Infinity }}
+                >
+                  <ArrowRight className='w-5 h-5' />
+                </motion.div>
+              </motion.button>
+              <motion.a
+                href='https://github.com/tinkle-community/nofx/tree/dev'
+                target='_blank'
+                rel='noopener noreferrer'
+                className='flex items-center gap-2 px-10 py-4 rounded-lg font-semibold text-lg'
+                style={{
+                  background: 'transparent',
+                  color: 'var(--brand-light-gray)',
+                  border: '2px solid var(--brand-yellow)',
+                }}
+                whileHover={{
+                  scale: 1.05,
+                  backgroundColor: 'rgba(240, 185, 11, 0.1)',
+                }}
+                whileTap={{ scale: 0.95 }}
+              >
+                {t('viewSourceCode', language)}
+              </motion.a>
+            </div>
           </div>
-        </div>
-      </AnimatedSection>
+        </AnimatedSection>
 
-      {showLoginModal && <LoginModal onClose={() => setShowLoginModal(false)} language={language} />}
-      <FooterSection language={language} />
+        {showLoginModal && (
+          <LoginModal
+            onClose={() => setShowLoginModal(false)}
+            language={language}
+          />
+        )}
+        <FooterSection language={language} />
       </div>
     </>
   )


### PR DESCRIPTION
## 问题描述
  修复 #422 - 登录成功后,页面交互跳转出现死循环

  ##   ##修复内容
  - 登录/注册成功后跳转到 `/traders` 页面而不是 `/`
  - 已登录用户点击"Get Started Now"直接进入 `/traders`
  - 未登录用户点击"Get Started Now"显示登录弹窗 