### PR TITLE
fix(market): prevent program crash on WebSocket failure

### DIFF
--- a/market/monitor.go
+++ b/market/monitor.go
@@ -121,19 +121,19 @@ func (m *WSMonitor) Start(coins []string) {
 	// 初始化交易对
 	err := m.Initialize(coins)
 	if err != nil {
-		log.Fatalf("❌ 初始化币种: %v", err)
+		log.Printf("❌ 初始化币种失败: %v", err)
 		return
 	}
 
 	err = m.combinedClient.Connect()
 	if err != nil {
-		log.Fatalf("❌ 批量订阅流: %v", err)
+		log.Printf("❌ 批量订阅流失败: %v", err)
 		return
 	}
 	// 订阅所有交易对
 	err = m.subscribeAll()
 	if err != nil {
-		log.Fatalf("❌ 订阅币种交易对: %v", err)
+		log.Printf("❌ 订阅币种交易对失败: %v", err)
 		return
 	}
 }
@@ -159,7 +159,7 @@ func (m *WSMonitor) subscribeAll() error {
 	for _, st := range subKlineTime {
 		err := m.combinedClient.BatchSubscribeKlines(m.symbols, st)
 		if err != nil {
-			log.Fatalf("❌ 订阅3m K线: %v", err)
+			log.Printf("❌ 订阅 %s K线失败: %v", st, err)
 			return err
 		}
 	}


### PR DESCRIPTION
## Problem
- Program crashes with log.Fatalf when WebSocket connection fails
- Triggered by WebSocket hijacking issue (157.240.12.50)
- Introduced in commit 3b1db6f (K-line WebSocket migration)

## Solution
- Replace 4x log.Fatalf with log.Printf in monitor.go
- Lines 177, 183, 189, 215
- Program now logs error and continues running

## Changes
1. Initialize failure: Fatalf → Printf (line 177)
2. Connection failure: Fatalf → Printf (line 183)
3. Subscribe failure: Fatalf → Printf (line 189)
4. K-line subscribe: Fatalf → Printf + dynamic period (line 215)

## Fallback
- System automatically uses API when WebSocket cache is empty
- GetCurrentKlines() has built-in degradation mechanism
- No data loss, slightly slower API calls as fallback

## Impact
- ✅ Program stability: Won't crash on network issues
- ✅ Error visibility: Clear error messages in logs
- ✅ Data integrity: API fallback ensures K-line availability

Related: websocket-hijack-fix.md, auto-stop-bug-analysis.md

# Pull Request: Fix WebSocket Crash (Clean Version)

## 🎯 PR信息

**分支**: `fix/websocket-crash`
**目标**: `NoFxAiOS/nofx` → `dev`
**来源**: `zhouyongyou/nofx` → `fix/websocket-crash`

## Problem

Program crashes when WebSocket connection fails, causing complete system shutdown.

**User report**: "程序运行一会就自动停止了" (Program auto-stops after running for a while)

### Root Cause

4 instances of `log.Fatalf` in `market/monitor.go` cause the entire program to exit when WebSocket operations fail:

- Line 124: Initialize failure
- Line 130: Connection failure
- Line 136: Subscribe failure
- Line 162: K-line subscribe failure

These fatal errors were introduced in commit **3b1db6f** during the K-line WebSocket migration.

### Trigger

- Network issues (ISP blocking, firewall)
- WebSocket connection hijacking (e.g., to Facebook IP 157.240.12.50)
- Temporary network instability

---

## Solution

Replace `log.Fatalf` with `log.Printf` to allow graceful error handling:

```go
// BEFORE (crashes entire program)
if err != nil {
    log.Fatalf("❌ 初始化币种: %v", err)
    return
}

// AFTER (logs error and continues)
if err != nil {
    log.Printf("❌ 初始化币种失败: %v", err)
    return
}
```

### Fallback Mechanism

The system has built-in fallback to API when WebSocket fails:

```go
// market/monitor.go:293-318
func (m *WSMonitor) GetCurrentKlines(...) {
    if !exists {
        // ✅ Automatically falls back to API
        klines, err := apiClient.GetKlines(symbol, _time, 100)
        // ... store in cache and continue
    }
}
```

This ensures K-line data remains available even when WebSocket fails.

---

## Changes

### Files Changed

```
market/monitor.go | 8 ++++----
1 file changed, 4 insertions(+), 4 deletions(-)
```

### Detailed Changes

```diff
-		log.Fatalf("❌ 初始化币种: %v", err)
+		log.Printf("❌ 初始化币种失败: %v", err)

-		log.Fatalf("❌ 批量订阅流: %v", err)
+		log.Printf("❌ 批量订阅流失败: %v", err)

-		log.Fatalf("❌ 订阅币种交易对: %v", err)
+		log.Printf("❌ 订阅币种交易对失败: %v", err)

-		log.Fatalf("❌ 订阅3m K线: %v", err)
+		log.Printf("❌ 订阅 %s K线失败: %v", st, err)
```

**Additional improvement**: Line 162 now shows dynamic K-line period (`%s`) instead of hardcoded "3m".

---

## Impact

### Before
- ❌ Program crashes on WebSocket failure
- ❌ Complete system shutdown
- ❌ Requires manual restart

### After
- ✅ Program logs error and continues running
- ✅ Automatically falls back to API for K-line data
- ✅ System remains operational

---

## Testing

- [x] Program continues running when WebSocket initialization fails
- [x] Program continues running when WebSocket connection fails
- [x] Program continues running when subscribe fails
- [x] K-line data still available via API fallback
- [x] Error messages clearly logged for debugging

---

## Severity

**Critical** - This issue causes complete program failure in production environments with network restrictions.

---

## Related

- Issue: WebSocket connection hijacking (157.240.12.50 Facebook IP)
- Analysis: `/Users/sotadic/Documents/GitHub/auto-stop-bug-analysis.md`
- Introduced: commit 3b1db6f (K-line WebSocket migration)
```

---

## 🚀 提交信息

**Commit**: `a7155e2`
**Date**: Wed Nov 5 01:10:49 2025 +0800
**Author**: ZhouYongyou

```
fix(market): prevent program crash on WebSocket failure

## Problem
- Program crashes with log.Fatalf when WebSocket connection fails
- Triggered by WebSocket hijacking issue (157.240.12.50)
- Introduced in commit 3b1db6f (K-line WebSocket migration)

## Solution
- Replace log.Fatalf with log.Printf in monitor.go
- Lines 177, 183, 189, 215
- Program now logs error and continues running

## Fallback
- System automatically uses API when WebSocket cache is empty
- GetCurrentKlines() has built-in degradation mechanism
- No data loss, slightly slower API calls as fallback

## Impact
- ✅ Program stability: Won't crash on network issues
- ✅ Error visibility: Clear error messages in logs
- ✅ Data integrity: API fallback ensures K-line availability

Related: websocket-hijack-fix.md, auto-stop-bug-analysis.md
```

---

## 📊 统计

**改动统计**:
- **文件数**: 1
- **新增行**: 4
- **删除行**: 4
- **净改动**: 0 行（纯替换）

**改动位置**:
- `market/monitor.go:124` - Initialize failure
- `market/monitor.go:130` - Connection failure
- `market/monitor.go:136` - Subscribe failure
- `market/monitor.go:162` - K-line subscribe failure

---

## ✅ 检查清单

- [x] 只包含 WebSocket crash fix
- [x] 没有引入新功能
- [x] 没有无关改动
- [x] Commit message 清晰
- [x] 易于审查（只有4行）
- [x] 测试通过

---

## 🎯 下一步操作

1. **访问 PR 创建链接**:
   ```
   https://github.com/NoFxAiOS/nofx/compare/dev...zhouyongyou:nofx:fix/websocket-crash
   ```

2. **复制 PR Description** (上面的内容)

3. **点击 "Create Pull Request"**

4. **等待审查和合并**

---

**分支**: `fix/websocket-crash` ✅
**状态**: 已推送到 origin
**大小**: 4 行改动（非常干净）🎉