### PR TITLE
fix: add AI_MAX_TOKENS environment variable to prevent response truncation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - /etc/localtime:/etc/localtime:ro  # Sync host time
     environment:
       - TZ=${NOFX_TIMEZONE:-Asia/Shanghai}  # Set timezone
+      - AI_MAX_TOKENS=4000  # AI响应的最大token数（默认2000，建议4000-8000）
     networks:
       - nofx-network
     healthcheck:

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -28,15 +30,28 @@ type Client struct {
 	Model      string
 	Timeout    time.Duration
 	UseFullURL bool // 是否使用完整URL（不添加/chat/completions）
+	MaxTokens  int  // AI响应的最大token数
 }
 
 func New() *Client {
+	// 从环境变量读取 MaxTokens，默认 2000
+	maxTokens := 2000
+	if envMaxTokens := os.Getenv("AI_MAX_TOKENS"); envMaxTokens != "" {
+		if parsed, err := strconv.Atoi(envMaxTokens); err == nil && parsed > 0 {
+			maxTokens = parsed
+			log.Printf("🔧 [MCP] 使用环境变量 AI_MAX_TOKENS: %d", maxTokens)
+		} else {
+			log.Printf("⚠️  [MCP] 环境变量 AI_MAX_TOKENS 无效 (%s)，使用默认值: %d", envMaxTokens, maxTokens)
+		}
+	}
+
 	// 默认配置
 	return &Client{
-		Provider: ProviderDeepSeek,
-		BaseURL:  "https://api.deepseek.com/v1",
-		Model:    "deepseek-chat",
-		Timeout:  120 * time.Second, // 增加到120秒，因为AI需要分析大量数据
+		Provider:  ProviderDeepSeek,
+		BaseURL:   "https://api.deepseek.com/v1",
+		Model:     "deepseek-chat",
+		Timeout:   120 * time.Second, // 增加到120秒，因为AI需要分析大量数据
+		MaxTokens: maxTokens,
 	}
 }
 
@@ -190,7 +205,7 @@ func (client *Client) callOnce(systemPrompt, userPrompt string) (string, error) 
 		"model":       client.Model,
 		"messages":    messages,
 		"temperature": 0.5, // 降低temperature以提高JSON格式稳定性
-		"max_tokens":  2000,
+		"max_tokens":  client.MaxTokens,
 	}
 
 	// 注意：response_format 参数仅 OpenAI 支持，DeepSeek/Qwen 不支持


### PR DESCRIPTION
## 🐛 Problem

AI responses were being truncated due to a hardcoded `max_tokens` limit of 2000, causing JSON parsing failures with the error:

```
❌ 获取AI决策失败: 解析AI响应失败: 提取决策失败: JSON解析失败: 
json: cannot unmarshal number into Go value of type decision.Decision
JSON内容: [-867, -937, -1020, -1029, -1237, -1378, -1582, -1936, -2116, -2328]
```

### Root Cause Analysis

1. **AI response truncated mid-analysis**: The 800-line trading strategy prompt + market data requires ~4000-6000 tokens total (input + output), but `max_tokens` was hardcoded to 2000
2. **AI's thought process cut off**: Response stopped at "**第2步：BTC状态确认（作为市场领导者）**\n- BTC 4h MACD序列："
3. **Wrong JSON extracted**: `extractDecisions()` found the first `[...]` array in the response, which was actually MACD indicator values from the input prompt: `[-867.759, -937.406, -1020.435, ...]`
4. **Parsing failed**: Go tried to unmarshal numbers into `Decision` struct

## ✅ Solution

- Add `MaxTokens` field to `mcp.Client` struct
- Read `AI_MAX_TOKENS` environment variable (default: 2000 if not set)
- Set `AI_MAX_TOKENS=4000` in `docker-compose.yml` for production
- Add proper logging for debugging

## 📝 Changes

### `mcp/client.go`
- Added `MaxTokens int` field to `Client` struct
- Modified `New()` to read `AI_MAX_TOKENS` from environment with fallback to 2000
- Updated `callOnce()` to use `client.MaxTokens` instead of hardcoded 2000
- Added logging: `🔧 [MCP] 使用环境变量 AI_MAX_TOKENS: 4000`

### `docker-compose.yml`
- Added `AI_MAX_TOKENS=4000` to nofx service environment variables

## 🧪 Testing

**Before fix:**
```
获取AI决策失败: JSON解析失败: json: cannot unmarshal number...
```

**After fix:**
```bash
# Docker will use 4000 tokens
docker compose up -d
docker compose logs nofx | grep "AI_MAX_TOKENS"
# Expected: 🔧 [MCP] 使用环境变量 AI_MAX_TOKENS: 4000

# Local testing with custom value
export AI_MAX_TOKENS=6000
go run main.go

# Without env var (uses default 2000)
unset AI_MAX_TOKENS
go run main.go
```

## 💡 Token Recommendations

- **2000** (default): Simple decision scenarios
- **4000** (production): Current 800-line strategy + market data ✅
- **6000-8000**: Future complex prompts

## 📊 Impact

- ✅ Prevents AI response truncation
- ✅ Ensures complete thought process and JSON output
- ✅ Flexible configuration via environment variable
- ✅ Safe default (2000) prevents cost issues
- ✅ No breaking changes (backward compatible)

## Related Issues

Fixes the JSON parsing error reported in decision logs.