### PR TITLE
feat(api): add server IP display for exchange whitelist configuration

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -291,6 +291,12 @@ export const translations = {
     viewGuide: 'View Guide',
     binanceSetupGuide: 'Binance Setup Guide',
     closeGuide: 'Close',
+    whitelistIP: 'Whitelist IP',
+    whitelistIPDesc: 'Binance requires adding server IP to API whitelist',
+    serverIPAddresses: 'Server IP Addresses',
+    copyIP: 'Copy',
+    ipCopied: 'IP Copied',
+    loadingServerIP: 'Loading server IP...',
 
     // Error Messages
     createTraderFailed: 'Failed to create trader',
@@ -758,6 +764,12 @@ export const translations = {
     viewGuide: '查看教程',
     binanceSetupGuide: '币安配置教程',
     closeGuide: '关闭',
+    whitelistIP: '白名单IP',
+    whitelistIPDesc: '币安交易所需要填写白名单IP',
+    serverIPAddresses: '服务器IP地址',
+    copyIP: '复制',
+    ipCopied: 'IP已复制',
+    loadingServerIP: '正在加载服务器IP...',
 
     // Error Messages
     createTraderFailed: '创建交易员失败',

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -327,4 +327,16 @@ export const api = {
     })
     if (!res.ok) throw new Error('保存用户信号源配置失败')
   },
-}
+
+  // 获取服务器IP（需要认证，用于白名单配置）
+  async getServerIP(): Promise<{
+    public_ip: string;
+    message: string;
+  }> {
+    const res = await fetch(`${API_BASE}/server-ip`, {
+      headers: getAuthHeaders(),
+    });
+    if (!res.ok) throw new Error('获取服务器IP失败');
+    return res.json();
+  },
+};


### PR DESCRIPTION
## 功能说明
为用户提供服务器公网IP地址显示，用于配置交易所API白名单（特别是Binance）

## 变更内容
- 后端新增 `/api/server-ip` 端点获取服务器公网IP
- 前端在Binance配置中显示服务器IP
- 支持一键复制IP地址
- 添加中英文国际化翻译

## 用户收益
- 简化Binance API白名单配置流程
- 显示准确的服务器IP地址
- 提供便捷的复制功能

## 测试建议
- [ √ ] 测试API端点 `/api/server-ip` 返回正确的公网IP
- [ √ ] 测试前端Binance配置页面正确显示IP
- [ √ ] 测试复制功能在不同浏览器中正常工作
<img width="649" height="856" alt="image" src="https://github.com/user-attachments/assets/9f167428-8835-4cb1-afd4-5c0d647bcb65" />
