### PR TITLE
docs: clarify Aster only supports EVM wallets

### DIFF
--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -198,7 +198,7 @@ export const translations = {
     hyperliquidWalletAddressDesc:
       'Wallet address corresponding to the private key',
     asterUserDesc:
-      'Main wallet address - The EVM wallet address you use to log in to Aster',
+      'Main wallet address - The EVM wallet address you use to log in to Aster (Note: Only EVM wallets are supported, Solana wallets are not supported)',
     asterSignerDesc:
       'API wallet address - Generate from https://www.asterdex.com/en/api-wallet',
     asterPrivateKeyDesc:
@@ -688,7 +688,7 @@ export const translations = {
     hyperliquidPrivateKeyDesc: 'Hyperliquid 使用私钥进行交易认证',
     hyperliquidWalletAddressDesc: '与私钥对应的钱包地址',
     asterUserDesc:
-      '主钱包地址 - 您用于登录 Aster 的 EVM 钱包地址',
+      '主钱包地址 - 您用于登录 Aster 的 EVM 钱包地址（注意：仅支持 EVM 钱包，不支持 Solana 钱包）',
     asterSignerDesc:
       'API 钱包地址 - 从 https://www.asterdex.com/zh-CN/api-wallet 生成',
     asterPrivateKeyDesc:


### PR DESCRIPTION
## 📝 Summary

Added wallet type restriction notice to Aster exchange configuration to clarify that only EVM wallets (Ethereum-compatible) are supported, Solana wallets are not supported.

## 🎯 Changes

- Updated English translation: Added "(Note: Only EVM wallets are supported, Solana wallets are not supported)" to `asterUserDesc`
- Updated Chinese translation: Added "（注意：仅支持 EVM 钱包，不支持 Solana 钱包）" to `asterUserDesc`

## 📋 Technical Analysis

Based on Aster official documentation and current code implementation:

### Aster Documentation Shows:
- Supports both EVM and Solana wallets
- Solana wallet requires `network: "SOL"` parameter when creating API keys

### Current NOFX Implementation:
- Uses `github.com/ethereum/go-ethereum` package (Ethereum ecosystem)
- Private key parsing: `crypto.HexToECDSA` (Ethereum ECDSA algorithm)
- Signature algorithm: Keccak256 + ECDSA (Ethereum standard)
- **Only supports EVM address format**

## ✅ Why This Change Matters

Users might try to use Solana wallets based on Aster's official documentation, but NOFX's current implementation only supports EVM wallets. This clarification prevents user confusion and configuration errors.

## 🧪 Testing

- [x] Verified translation strings display correctly in UI
- [x] Checked both English and Chinese tooltip texts

## 📸 Visual Changes

The tooltip for Aster "User" field now clearly indicates EVM-only support in both languages.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)