### PR TITLE
fix: resolve build errors and remove duplicate CancelStopOrders methods

### DIFF
--- a/trader/aster_trader.go
+++ b/trader/aster_trader.go
@@ -1175,61 +1175,6 @@ func (t *AsterTrader) CancelAllOrders(symbol string) error {
 	return err
 }
 
-// CancelStopOrders 取消该币种的止盈/止损单（用于调整止盈止损位置）
-func (t *AsterTrader) CancelStopOrders(symbol string) error {
-	// 获取该币种的所有未完成订单
-	params := map[string]interface{}{
-		"symbol": symbol,
-	}
-
-	body, err := t.request("GET", "/fapi/v3/openOrders", params)
-	if err != nil {
-		return fmt.Errorf("获取未完成订单失败: %w", err)
-	}
-
-	var orders []map[string]interface{}
-	if err := json.Unmarshal(body, &orders); err != nil {
-		return fmt.Errorf("解析订单数据失败: %w", err)
-	}
-
-	// 过滤出止盈止损单并取消
-	canceledCount := 0
-	for _, order := range orders {
-		orderType, _ := order["type"].(string)
-
-		// 只取消止损和止盈订单
-		if orderType == "STOP_MARKET" ||
-			orderType == "TAKE_PROFIT_MARKET" ||
-			orderType == "STOP" ||
-			orderType == "TAKE_PROFIT" {
-
-			orderID, _ := order["orderId"].(float64)
-			cancelParams := map[string]interface{}{
-				"symbol":  symbol,
-				"orderId": int64(orderID),
-			}
-
-			_, err := t.request("DELETE", "/fapi/v3/order", cancelParams)
-			if err != nil {
-				log.Printf("  ⚠ 取消订单 %d 失败: %v", int64(orderID), err)
-				continue
-			}
-
-			canceledCount++
-			log.Printf("  ✓ 已取消 %s 的止盈/止损单 (订单ID: %d, 类型: %s)",
-				symbol, int64(orderID), orderType)
-		}
-	}
-
-	if canceledCount == 0 {
-		log.Printf("  ℹ %s 没有止盈/止损单需要取消", symbol)
-	} else {
-		log.Printf("  ✓ 已取消 %s 的 %d 个止盈/止损单", symbol, canceledCount)
-	}
-
-	return nil
-}
-
 // FormatQuantity 格式化数量（实现Trader接口）
 func (t *AsterTrader) FormatQuantity(symbol string, quantity float64) (string, error) {
 	formatted, err := t.formatQuantity(symbol, quantity)

--- a/trader/auto_trader.go
+++ b/trader/auto_trader.go
@@ -465,12 +465,11 @@ func (at *AutoTrader) runCycle() error {
 
 		// 打印系统提示词和AI思维链（即使有错误，也要输出以便调试）
 		if decision != nil {
-				log.Print("\n" + strings.Repeat("=", 70) + "\n")
-				log.Printf("📋 系统提示词 [模板: %s] (错误情况)", at.systemPromptTemplate)
-				log.Println(strings.Repeat("=", 70))
-				log.Println(decision.SystemPrompt)
-				log.Println(strings.Repeat("=", 70))
-			}
+			log.Print("\n" + strings.Repeat("=", 70) + "\n")
+			log.Printf("📋 系统提示词 [模板: %s] (错误情况)", at.systemPromptTemplate)
+			log.Println(strings.Repeat("=", 70))
+			log.Println(decision.SystemPrompt)
+			log.Println(strings.Repeat("=", 70))
 
 			if decision.CoTTrace != "" {
 				log.Print("\n" + strings.Repeat("-", 70) + "\n")
@@ -509,9 +508,6 @@ func (at *AutoTrader) runCycle() error {
 	//     }
 	// }
 	log.Println()
-				log.Print(strings.Repeat("-", 70))
-	// 8. 对决策排序：确保先平仓后开仓（防止仓位叠加超限）
-				log.Print(strings.Repeat("-", 70))
 
 	// 8. 对决策排序：确保先平仓后开仓（防止仓位叠加超限）
 	sortedDecisions := sortDecisionsByPriority(decision.Decisions)

--- a/trader/binance_futures.go
+++ b/trader/binance_futures.go
@@ -636,53 +636,6 @@ func (t *FuturesTrader) CancelAllOrders(symbol string) error {
 	return nil
 }
 
-// CancelStopOrders 取消该币种的止盈/止损单（用于调整止盈止损位置）
-func (t *FuturesTrader) CancelStopOrders(symbol string) error {
-	// 获取该币种的所有未完成订单
-	orders, err := t.client.NewListOpenOrdersService().
-		Symbol(symbol).
-		Do(context.Background())
-
-	if err != nil {
-		return fmt.Errorf("获取未完成订单失败: %w", err)
-	}
-
-	// 过滤出止盈止损单并取消
-	canceledCount := 0
-	for _, order := range orders {
-		orderType := order.Type
-
-		// 只取消止损和止盈订单
-		if orderType == futures.OrderTypeStopMarket ||
-			orderType == futures.OrderTypeTakeProfitMarket ||
-			orderType == futures.OrderTypeStop ||
-			orderType == futures.OrderTypeTakeProfit {
-
-			_, err := t.client.NewCancelOrderService().
-				Symbol(symbol).
-				OrderID(order.OrderID).
-				Do(context.Background())
-
-			if err != nil {
-				log.Printf("  ⚠ 取消订单 %d 失败: %v", order.OrderID, err)
-				continue
-			}
-
-			canceledCount++
-			log.Printf("  ✓ 已取消 %s 的止盈/止损单 (订单ID: %d, 类型: %s)",
-				symbol, order.OrderID, orderType)
-		}
-	}
-
-	if canceledCount == 0 {
-		log.Printf("  ℹ %s 没有止盈/止损单需要取消", symbol)
-	} else {
-		log.Printf("  ✓ 已取消 %s 的 %d 个止盈/止损单", symbol, canceledCount)
-	}
-
-	return nil
-}
-
 // GetMarketPrice 获取市场价格
 func (t *FuturesTrader) GetMarketPrice(symbol string) (float64, error) {
 	prices, err := t.client.NewListPricesService().Symbol(symbol).Do(context.Background())

--- a/trader/hyperliquid_trader.go
+++ b/trader/hyperliquid_trader.go
@@ -623,40 +623,6 @@ func (t *HyperliquidTrader) CancelAllOrders(symbol string) error {
 	return nil
 }
 
-// CancelStopOrders 取消该币种的止盈/止损单（用于调整止盈止损位置）
-func (t *HyperliquidTrader) CancelStopOrders(symbol string) error {
-	coin := convertSymbolToHyperliquid(symbol)
-
-	// 获取所有挂单
-	openOrders, err := t.exchange.Info().OpenOrders(t.ctx, t.walletAddr)
-	if err != nil {
-		return fmt.Errorf("获取挂单失败: %w", err)
-	}
-
-	// 注意：Hyperliquid SDK 的 OpenOrder 结构不暴露 trigger 字段
-	// 因此暂时取消该币种的所有挂单（包括止盈止损单）
-	// 这是安全的，因为在设置新的止盈止损之前，应该清理所有旧订单
-	canceledCount := 0
-	for _, order := range openOrders {
-		if order.Coin == coin {
-			_, err := t.exchange.Cancel(t.ctx, coin, order.Oid)
-			if err != nil {
-				log.Printf("  ⚠ 取消订单失败 (oid=%d): %v", order.Oid, err)
-				continue
-			}
-			canceledCount++
-		}
-	}
-
-	if canceledCount == 0 {
-		log.Printf("  ℹ %s 没有挂单需要取消", symbol)
-	} else {
-		log.Printf("  ✓ 已取消 %s 的 %d 个挂单（包括止盈/止损单）", symbol, canceledCount)
-	}
-
-	return nil
-}
-
 // GetMarketPrice 获取市场价格
 func (t *HyperliquidTrader) GetMarketPrice(symbol string) (float64, error) {
 	coin := convertSymbolToHyperliquid(symbol)

--- a/trader/interface.go
+++ b/trader/interface.go
@@ -49,9 +49,6 @@ type Trader interface {
 	// CancelAllOrders 取消该币种的所有挂单
 	CancelAllOrders(symbol string) error
 
-	// CancelStopOrders 取消该币种的止盈/止损单（用于调整止盈止损位置）
-	CancelStopOrders(symbol string) error
-
 	// FormatQuantity 格式化数量到正确的精度
 	FormatQuantity(symbol string, quantity float64) (string, error)
 }


### PR DESCRIPTION
## Summary
- 修复 `auto_trader.go` 中的语法错误（错误缩进导致）
- 删除 `interface.go` 中重复的 `CancelStopOrders` 方法声明
- 删除 `aster_trader.go`、`binance_futures.go`、`hyperliquid_trader.go` 中重复的 `CancelStopOrders` 方法实现
- 清理了异常缩进的日志语句

## Changes
- `trader/auto_trader.go`: 修复缩进错误，删除多余的重复日志代码
- `trader/interface.go`: 删除重复的方法声明
- `trader/aster_trader.go`: 删除重复的 `CancelStopOrders` 方法
- `trader/binance_futures.go`: 删除重复的 `CancelStopOrders` 方法
- `trader/hyperliquid_trader.go`: 删除重复的 `CancelStopOrders` 方法

## Test plan
- [x] 项目构建成功 (`go build`)
- [x] 删除了 148 行重复代码
- [x] 保留了原有的 `CancelStopOrders` 方法功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)