### PR TITLE
feat: auto-start traders in admin mode on service restart

### DIFF
--- a/main.go
+++ b/main.go
@@ -334,8 +334,12 @@ func main() {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
-	// TODO: 启动数据库中配置为运行状态的交易员
-	// traderManager.StartAll()
+	// Admin模式下自动启动标记为运行状态的交易员
+	if adminMode {
+		if err := traderManager.StartRunningTraders(database); err != nil {
+			log.Printf("⚠️  自动启动交易员失败: %v", err)
+		}
+	}
 
 	// 等待退出信号
 	<-sigChan

--- a/manager/trader_manager.go
+++ b/manager/trader_manager.go
@@ -441,6 +441,54 @@ func (tm *TraderManager) StartAll() {
 	}
 }
 
+// StartRunningTraders 只启动数据库中标记为运行状态的交易员
+func (tm *TraderManager) StartRunningTraders(database *config.Database) error {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	// 获取所有用户
+	userIDs, err := database.GetAllUsers()
+	if err != nil {
+		return fmt.Errorf("获取用户列表失败: %w", err)
+	}
+
+	// 收集所有应该启动的交易员
+	var runningTraders []*config.TraderRecord
+	for _, userID := range userIDs {
+		traders, err := database.GetTraders(userID)
+		if err != nil {
+			log.Printf("⚠️ 获取用户 %s 的交易员失败: %v", userID, err)
+			continue
+		}
+		for _, trader := range traders {
+			if trader.IsRunning {
+				runningTraders = append(runningTraders, trader)
+			}
+		}
+	}
+
+	if len(runningTraders) == 0 {
+		log.Println("📋 没有需要自动启动的交易员")
+		return nil
+	}
+
+	log.Printf("🚀 自动启动 %d 个标记为运行状态的交易员...", len(runningTraders))
+	for _, traderCfg := range runningTraders {
+		if t, exists := tm.traders[traderCfg.ID]; exists {
+			go func(at *trader.AutoTrader, name string) {
+				log.Printf("▶️  启动 %s...", name)
+				if err := at.Run(); err != nil {
+					log.Printf("❌ %s 运行错误: %v", name, err)
+				}
+			}(t, traderCfg.Name)
+		} else {
+			log.Printf("⚠️  交易员 %s (ID: %s) 未加载到内存，跳过", traderCfg.Name, traderCfg.ID)
+		}
+	}
+
+	return nil
+}
+
 // StopAll 停止所有trader
 func (tm *TraderManager) StopAll() {
 	tm.mu.RLock()


### PR DESCRIPTION
Closes #574

## Summary / 概述

Automatically restarts traders that were running before service restart in admin mode. This improves local development experience while keeping cloud deployments safe.

在 admin 模式下，自动重启服务重启前正在运行的交易员。这改善了本地开发体验，同时保持云端部署的安全性。

## Changes / 修改内容

### 1. Added `StartRunningTraders` method / 新增 `StartRunningTraders` 方法

**Location:** `manager/trader_manager.go:444-490`

- Queries database for all traders with `is_running=true`
- Only starts traders that are loaded in memory
- Logs progress and skips missing traders
- 查询数据库中所有 `is_running=true` 的交易员
- 只启动已加载到内存的交易员
- 记录进度并跳过缺失的交易员

### 2. Auto-start in admin mode / Admin 模式下自动启动

**Location:** `main.go:313-318`

- Calls `StartRunningTraders()` when `admin_mode=true`
- No auto-start when `admin_mode=false` (cloud deployments)
- 当 `admin_mode=true` 时调用 `StartRunningTraders()`
- 当 `admin_mode=false` 时不自动启动（云端部署）

## Testing / 测试验证

### Test Case 1: Trader with is_running=0 / 测试场景 1：is_running=0

```bash
# Stop trader
curl -X POST http://localhost:8080/api/traders/{id}/stop

# Verify database
sqlite3 config.db "SELECT is_running FROM traders"
# Output: 0

# Restart service
docker compose restart nofx

# Check logs
docker compose logs nofx | grep "自动启动"
# Output: 📋 没有需要自动启动的交易员
```

✅ **Result:** No auto-start (expected behavior)

### Test Case 2: Trader with is_running=1 / 测试场景 2：is_running=1

```bash
# Start trader
curl -X POST http://localhost:8080/api/traders/{id}/start

# Verify database
sqlite3 config.db "SELECT is_running FROM traders"
# Output: 1

# Restart service
docker compose restart nofx

# Check logs
docker compose logs nofx | grep "自动启动"
# Output: 🚀 自动启动 1 个标记为运行状态的交易员...
#         ▶️  启动 招财猫...
```

✅ **Result:** Auto-started successfully (expected behavior)

## Benefits / 优点

### For Local Development / 本地开发

- ✅ Traders automatically resume after container restart
- ✅ No need to manually restart via UI/API
- ✅ Maintains trader state across restarts
- ✅ 交易员在容器重启后自动恢复
- ✅ 无需通过 UI/API 手动重启
- ✅ 保持交易员状态跨重启

### For Cloud Deployment / 云端部署

- ✅ Safe: No auto-start when `admin_mode=false`
- ✅ Users must explicitly start traders via API
- ✅ Better control over resource usage
- ✅ 安全：`admin_mode=false` 时不自动启动
- ✅ 用户必须通过 API 显式启动交易员
- ✅ 更好地控制资源使用

## ⚠️ Reviewer Notes / 审查注意事项

### Potential Concerns for Multi-User Scenarios / 多用户场景的潜在影响

**Please consider the following when reviewing:**

1. **API Rate Limiting / API 限流影响**
   - All traders with `is_running=true` start simultaneously on service restart
   - This could cause burst requests to third-party APIs (exchanges, AI models, market data)
   - Consider: Should we add staggered startup delays?
   - 所有 `is_running=true` 的交易员在服务重启时同时启动
   - 可能对第三方 API（交易所、AI 模型、行情数据）造成瞬时请求冲击
   - 考虑：是否需要添加错峰启动延迟？

2. **System Resource Usage / 系统资源使用**
   - Multiple traders starting concurrently could spike CPU/memory usage
   - Current implementation: All traders start via goroutines (non-blocking)
   - Consider: Should we limit concurrent starts or add resource monitoring?
   - 多个交易员并发启动可能导致 CPU/内存使用峰值
   - 当前实现：所有交易员通过 goroutine 启动（非阻塞）
   - 考虑：是否需要限制并发启动数量或添加资源监控？

3. **Database Load / 数据库负载**
   - Current: Queries all users and traders at startup
   - Impact: Should be minimal for typical deployments
   - Consider: Is the current query pattern efficient for large user bases?
   - 当前：启动时查询所有用户和交易员
   - 影响：对典型部署应该影响较小
   - 考虑：对于大量用户场景，当前查询模式是否高效？

**Current Mitigations / 当前的缓解措施：**

- ✅ Only active in `admin_mode=true` (typically single-user local dev)
- ✅ Uses goroutines to avoid blocking startup
- ✅ Logs clearly show startup progress
- ✅ 仅在 `admin_mode=true` 时启用（通常是单用户本地开发）
- ✅ 使用 goroutine 避免阻塞启动流程
- ✅ 日志清晰显示启动进度

**Suggested Future Improvements / 未来改进建议：**

- [ ] Add configurable startup delay between traders (e.g., 100-500ms)
- [ ] Implement batch startup with size limits (e.g., 5 traders at a time)
- [ ] Add startup timeout and failure recovery
- [ ] Monitor and log API rate limit responses
- [ ] 添加可配置的交易员启动间隔（如 100-500ms）
- [ ] 实现批量启动，限制批次大小（如每次 5 个交易员）
- [ ] 添加启动超时和失败恢复机制
- [ ] 监控和记录 API 限流响应

## Configuration / 配置

Set in `config.json`:

```json
{
  "admin_mode": true   // Enable auto-start (local dev)
}
```

or

```json
{
  "admin_mode": false  // Disable auto-start (cloud)
}
```

## Related / 相关信息

- Resolves TODO at `main.go:313`
- Compatible with existing trader management APIs
- No breaking changes
- 解决了 `main.go:313` 处的 TODO
- 兼容现有的交易员管理 API
- 无破坏性改动