### PR TITLE
fix: pass highest return rate and P&L metrics to AI decision prompt

### DIFF
--- a/decision/engine.go
+++ b/decision/engine.go
@@ -33,6 +33,7 @@ type PositionInfo struct {
 	Leverage         int     `json:"leverage"`
 	UnrealizedPnL    float64 `json:"unrealized_pnl"`
 	UnrealizedPnLPct float64 `json:"unrealized_pnl_pct"`
+	PeakPnLPct       float64 `json:"peak_pnl_pct"`       // 历史最高收益率（百分比）
 	LiquidationPrice float64 `json:"liquidation_price"`
 	MarginUsed       float64 `json:"margin_used"`
 	UpdateTime       int64   `json:"update_time"` // 持仓更新时间戳（毫秒）
@@ -374,9 +375,9 @@ func buildUserPrompt(ctx *Context) string {
 				}
 			}
 
-			sb.WriteString(fmt.Sprintf("%d. %s %s | 入场价%.4f 当前价%.4f | 盈亏%+.2f%% | 杠杆%dx | 保证金%.0f | 强平价%.4f%s\n\n",
+			sb.WriteString(fmt.Sprintf("%d. %s %s | 入场价%.4f 当前价%.4f | 盈亏%+.2f%% | 盈亏金额%+.2f USDT | 最高收益率%.2f%% | 杠杆%dx | 保证金%.0f | 强平价%.4f%s\n\n",
 				i+1, pos.Symbol, strings.ToUpper(pos.Side),
-				pos.EntryPrice, pos.MarkPrice, pos.UnrealizedPnLPct,
+				pos.EntryPrice, pos.MarkPrice, pos.UnrealizedPnLPct, pos.UnrealizedPnL, pos.PeakPnLPct,
 				pos.Leverage, pos.MarginUsed, pos.LiquidationPrice, holdingDuration))
 
 			// 使用FormatMarketData输出完整市场数据

--- a/trader/auto_trader.go
+++ b/trader/auto_trader.go
@@ -636,6 +636,11 @@ func (at *AutoTrader) buildTradingContext() (*decision.Context, error) {
 		}
 		updateTime := at.positionFirstSeenTime[posKey]
 
+		// 获取该持仓的历史最高收益率
+		at.peakPnLCacheMutex.RLock()
+		peakPnlPct := at.peakPnLCache[symbol]
+		at.peakPnLCacheMutex.RUnlock()
+
 		positionInfos = append(positionInfos, decision.PositionInfo{
 			Symbol:           symbol,
 			Side:             side,
@@ -645,6 +650,7 @@ func (at *AutoTrader) buildTradingContext() (*decision.Context, error) {
 			Leverage:         leverage,
 			UnrealizedPnL:    unrealizedPnl,
 			UnrealizedPnLPct: pnlPct,
+			PeakPnLPct:       peakPnlPct,
 			LiquidationPrice: liquidationPrice,
 			MarginUsed:       marginUsed,
 			UpdateTime:       updateTime,


### PR DESCRIPTION
## Summary
Fixes #652 

- Fixed missing profit/loss metrics not being passed to AI for decision-making
- Added 历史最高收益率（百分比）(historical highest return rate percentage) to AI prompt
- Added 盈亏金额 USDT (profit/loss amount in USDT) to AI prompt
- Added 最高收益率 (highest return rate) to `PositionInfo` struct and AI prompt context

## Changes

### decision/engine.go
- Added `PeakPnLPct` field to `PositionInfo` struct to store historical peak P&L percentage
- Updated `buildUserPrompt()` to include profit/loss amount in USDT and peak return rate in position display

### trader/auto_trader.go  
- Modified `buildTradingContext()` to read `peakPnLCache` and populate `PeakPnLPct` field
- Used proper read lock (`RLock`) for thread-safe cache access

## Before (AI Prompt)
```
1. BTCUSDT LONG | 入场价50000.0000 当前价55000.0000 | 盈亏+10.00% | 杠杆10x | 保证金5000 | 强平价45000.0000
```

## After (AI Prompt)  
```
1. BTCUSDT LONG | 入场价50000.0000 当前价55000.0000 | 盈亏+10.00% | 盈亏金额+5000.00 USDT | 最高收益率15.00% | 杠杆10x | 保证金5000 | 强平价45000.0000
```

## Known Issue

⚠️ **There is a critical bug in the existing `peakPnLCache` implementation** (NOT introduced by this PR):

The cache uses `symbol` as key instead of `symbol_side`, which causes incorrect peak P&L values when holding dual positions (both long and short) of the same symbol. This is documented in issue #652.

This PR passes the cached peak values to AI as-is. The underlying cache key bug needs to be fixed separately.

## Test plan
- [x] Verified `PeakPnLPct` field is correctly added to `PositionInfo` struct
- [x] Verified profit/loss metrics are included in AI prompt  
- [x] Verified thread-safe access to `peakPnLCache` using `RLock`
- [ ] Manual test: Create position and verify AI receives complete metrics in prompt
- [ ] Manual test: Verify AI can use peak return rate and P&L amount for decision-making