### PR TITLE
fix(web): prevent NaN% display in competition gap calculation (#633)

### DIFF
--- a/web/src/components/CompetitionPage.tsx
+++ b/web/src/components/CompetitionPage.tsx
@@ -392,7 +392,7 @@ export function CompetitionPage() {
             {sortedTraders.map((trader, index) => {
               const isWinning = index === 0
               const opponent = sortedTraders[1 - index]
-              const gap = trader.total_pnl_pct - opponent.total_pnl_pct
+              const gap = (trader.total_pnl_pct ?? 0) - (opponent.total_pnl_pct ?? 0)
 
               return (
                 <div


### PR DESCRIPTION
## Summary

Fixes "NaN%" display in competition page's head-to-head comparison when trader P&L percentage data is null or undefined.

### Problem

Competition page shows confusing "NaN%" for gap difference:

**Example:**
```
交易員 A: +5.23%
交易員 B: --% (data missing)
當前差距: 領先 NaN%  ❌
```

### Root Cause

**File:** `web/src/components/CompetitionPage.tsx:395`

```typescript
// ❌ Before: Missing null checks
const gap = trader.total_pnl_pct - opponent.total_pnl_pct
// If either value is null/undefined → NaN
```

When either trader has missing `total_pnl_pct` data:
- `undefined - 5.23` = `NaN`
- `5.23 - null` = `NaN`
- Display shows "領先 NaN%" or "落後 NaN%"

### Solution

Add null coalescing operator to default missing values to 0:

```typescript
// ✅ After: Graceful degradation
const gap = (trader.total_pnl_pct ?? 0) - (opponent.total_pnl_pct ?? 0)
```

**Behavior:**
- If data missing → gap defaults to 0.00%
- Prevents confusing "NaN%" display
- Maintains correct calculation when both values present

## Changes

- **File:** `web/src/components/CompetitionPage.tsx`
- **Line:** 395
- **Change:** Add `?? 0` null coalescing to both operands

## Impact

- ✅ Eliminates "NaN%" display in competition page
- ✅ Shows "0.00%" when data is incomplete (better UX)
- ✅ No breaking changes - pure defensive coding
- ✅ Aligns with existing pattern (line 253: `total_pnl ?? 0`)

## Testing

- ✅ Verified null coalescing pattern consistent with codebase
- ✅ Manual inspection of competition page logic

Fixes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>