### PR TITLE
fix: 修复币安白名单IP复制功能失效问题

### DIFF
--- a/web/src/components/AITradersPage.tsx
+++ b/web/src/components/AITradersPage.tsx
@@ -1729,11 +1729,41 @@ function ExchangeConfigModal({
     }
   }, [selectedExchangeId])
 
-  const handleCopyIP = (ip: string) => {
-    navigator.clipboard.writeText(ip).then(() => {
-      setCopiedIP(true)
-      setTimeout(() => setCopiedIP(false), 2000)
-    })
+  const handleCopyIP = async (ip: string) => {
+    try {
+      // 优先使用现代 Clipboard API
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(ip)
+        setCopiedIP(true)
+        setTimeout(() => setCopiedIP(false), 2000)
+      } else {
+        // 降级方案: 使用传统的 execCommand 方法
+        const textArea = document.createElement('textarea')
+        textArea.value = ip
+        textArea.style.position = 'fixed'
+        textArea.style.left = '-999999px'
+        textArea.style.top = '-999999px'
+        document.body.appendChild(textArea)
+        textArea.focus()
+        textArea.select()
+
+        try {
+          const successful = document.execCommand('copy')
+          if (successful) {
+            setCopiedIP(true)
+            setTimeout(() => setCopiedIP(false), 2000)
+          } else {
+            throw new Error('复制命令执行失败')
+          }
+        } finally {
+          document.body.removeChild(textArea)
+        }
+      }
+    } catch (err) {
+      console.error('复制失败:', err)
+      // 显示错误提示
+      alert(t('copyIPFailed', language) || `复制失败: ${ip}\n请手动复制此IP地址`)
+    }
   }
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -304,6 +304,7 @@ export const translations = {
     serverIPAddresses: 'Server IP Addresses',
     copyIP: 'Copy',
     ipCopied: 'IP Copied',
+    copyIPFailed: 'Failed to copy IP address. Please copy manually',
     loadingServerIP: 'Loading server IP...',
 
     // Error Messages
@@ -965,6 +966,7 @@ export const translations = {
     serverIPAddresses: '服务器IP地址',
     copyIP: '复制',
     ipCopied: 'IP已复制',
+    copyIPFailed: 'IP地址复制失败，请手动复制',
     loadingServerIP: '正在加载服务器IP...',
 
     // Error Messages


### PR DESCRIPTION
## 🐛 问题描述
币安交易所配置页面中的服务器IP复制功能无法正常工作

## 🔍 根因分析
原始实现仅使用 navigator.clipboard.writeText() API:
- 在某些浏览器环境下不可用或被阻止
- 需要 HTTPS 或 localhost 环境
- 缺少错误处理和用户反馈

## ✅ 修复方案
1. **双重降级机制**:
   - 优先使用现代 Clipboard API
   - 降级到传统 execCommand 方法

2. **错误处理**:
   - 添加 try-catch 错误捕获
   - 失败时显示友好的错误提示
   - 提供IP地址供用户手动复制

3. **多语言支持**:
   - 添加 copyIPFailed 翻译键(中英文)

## 📝 修改文件
- web/src/components/AITradersPage.tsx
  - handleCopyIP 函数重构为异步函数
  - 添加双重复制机制和错误处理

- web/src/i18n/translations.ts
  - 添加 copyIPFailed 错误提示翻译

## 🧪 测试验证
✅ TypeScript 编译通过
✅ Vite 构建成功
✅ 支持现代和传统浏览器环境

