### PR TITLE
sync cache when delete trader

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -734,6 +734,9 @@ func (s *Server) handleDeleteTrader(c *gin.Context) {
 		}
 	}
 
+	// 无论是否在内存中，尝试移除并清空竞赛缓存
+	s.traderManager.RemoveTrader(traderID)
+
 	log.Printf("✓ 交易员已删除: %s", traderID)
 	c.JSON(http.StatusOK, gin.H{"message": "交易员已删除"})
 }

--- a/manager/trader_manager.go
+++ b/manager/trader_manager.go
@@ -401,6 +401,18 @@ func (tm *TraderManager) GetTrader(id string) (*trader.AutoTrader, error) {
 	return t, nil
 }
 
+// RemoveTrader 从内存中移除指定trader并清空竞赛缓存
+func (tm *TraderManager) RemoveTrader(id string) {
+	tm.mu.Lock()
+	delete(tm.traders, id)
+	tm.mu.Unlock()
+
+	tm.competitionCache.mu.Lock()
+	tm.competitionCache.data = make(map[string]interface{})
+	tm.competitionCache.timestamp = time.Time{}
+	tm.competitionCache.mu.Unlock()
+}
+
 // GetAllTraders 获取所有trader
 func (tm *TraderManager) GetAllTraders() map[string]*trader.AutoTrader {
 	tm.mu.RLock()


### PR DESCRIPTION
# Pull Request - Backend | 后端 PR

> **💡 提示 Tip:** 推荐 PR 标题格式 `type(scope): description`
> 例如: `feat(trader): add new strategy` | `fix(api): resolve auth issue`

---

## 📝 Description | 描述

**English:** Ensure deleting a trader also drops the in-memory instance and resets the competition cache so stale standings don’t linger after removal.  
**中文：** 删除交易员时同步移除内存中的交易员并清空竞赛缓存，避免删除后仍展示过期的竞赛数据。

---

## 🎯 Type of Change | 变更类型

- [x] 🐛 Bug fix | 修复 Bug
- [ ] ✨ New feature | 新功能
- [ ] 💥 Breaking change | 破坏性变更
- [ ] ♻️ Refactoring | 重构
- [ ] ⚡ Performance improvement | 性能优化
- [ ] 🔒 Security fix | 安全修复
- [ ] 🔧 Build/config change | 构建/配置变更

---

## 🔗 Related Issues | 相关 Issue

- N/A

---

## 📋 Changes Made | 具体变更

**English:** ｜ **中文：**
- `api/server.go`: 调用 `TraderManager.RemoveTrader`，无论交易员是否仍在内存中都尝试清理，并确保删除操作也刷新竞赛缓存。  
- `manager/trader_manager.go`: 新增 `RemoveTrader` 方法，安全地移除指定交易员并重置 `competitionCache` 的数据与时间戳，杜绝后续请求命中旧缓存。

---

## 🧪 Testing | 测试

### Test Environment | 测试环境
- **OS | 操作系统:** macOS 15.1 (Apple Silicon)
- **Go Version | Go 版本:** go1.25.3
- **Exchange | 交易所:** N/A

### Manual Testing | 手动测试
- [x] Tested locally | 本地测试通过
- [ ] Tested on testnet | 测试网测试通过（交易所集成相关）
- [x] Unit tests pass | 单元测试通过
- [x] Verified no existing functionality broke | 确认没有破坏现有功能

### Test Results | 测试结果
```
GOCACHE=$(pwd)/.cache/go-build go test ./...
```

---

## 🔒 Security Considerations | 安全考虑

- [x] N/A (not security-related) | 不适用

---

## ⚡ Performance Impact | 性能影响

- [x] No significant performance impact | 无显著性能影响

**If impacted, explain | 如果受影响，请说明：**
N/A

---

## ✅ Checklist | 检查清单

### Code Quality | 代码质量
- [x] Code follows project style | 代码遵循项目风格
- [x] Self-review completed | 已完成代码自查
- [x] Comments added for complex logic | 已添加必要注释
- [x] Code compiles successfully | 代码编译成功 (`go build`)
- [x] Ran `go fmt` | 已运行 `go fmt`

### Documentation | 文档
- [x] Updated relevant documentation | 已更新相关文档（PR 模板）
- [x] Added inline comments where necessary | 已添加必要的代码注释
- [ ] Updated API documentation (if applicable) | 已更新 API 文档

### Git
- [x] Commits follow conventional format | 提交遵循 Conventional Commits 格式
- [x] Rebased on latest `dev` branch | 已 rebase 到最新 `dev` 分支
- [x] No merge conflicts | 无合并冲突

---

## 📚 Additional Notes | 补充说明

**English:** The cache reset is intentionally broad to guarantee no dangling competition data; follow-ups can refine scope if perf impact surfaces.  
**中文：** 为确保不再有残留竞赛数据，此次清缓存采用全量重置；若后续发现性能需求，可再细化清理策略。

---

**By submitting this PR, I confirm | 提交此 PR，我确认：**

- [x] I have read the [Contributing Guidelines](../../CONTRIBUTING.md) | 已阅读贡献指南
- [x] I agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md) | 同意行为准则
- [x] My contribution is licensed under AGPL-3.0 | 贡献遵循 AGPL-3.0 许可证

---

🌟 **Thank you for your contribution! | 感谢你的贡献！**
