### PR TITLE
fix: 支持 NOFX_BACKEND_PORT 环境变量配置端口

### DIFF
--- a/main.go
+++ b/main.go
@@ -203,7 +203,6 @@ func main() {
 	useDefaultCoins := useDefaultCoinsStr == "true"
 	apiPortStr, _ := database.GetSystemConfig("api_server_port")
 
-
 	// 设置JWT密钥（优先使用环境变量）
 	jwtSecret := strings.TrimSpace(os.Getenv("JWT_SECRET"))
 	if jwtSecret == "" {
@@ -317,12 +316,25 @@ func main() {
 	fmt.Println(strings.Repeat("=", 60))
 	fmt.Println()
 
-	// 获取API服务器端口
+	// 获取API服务器端口（优先级：环境变量 > 数据库配置 > 默认值）
 	apiPort := 8080 // 默认端口
-	if apiPortStr != "" {
-		if port, err := strconv.Atoi(apiPortStr); err == nil {
+
+	// 1. 优先从环境变量 NOFX_BACKEND_PORT 读取
+	if envPort := strings.TrimSpace(os.Getenv("NOFX_BACKEND_PORT")); envPort != "" {
+		if port, err := strconv.Atoi(envPort); err == nil && port > 0 {
 			apiPort = port
+			log.Printf("🔌 使用环境变量端口: %d (NOFX_BACKEND_PORT)", apiPort)
+		} else {
+			log.Printf("⚠️  环境变量 NOFX_BACKEND_PORT 无效: %s", envPort)
 		}
+	} else if apiPortStr != "" {
+		// 2. 从数据库配置读取（config.json 同步过来的）
+		if port, err := strconv.Atoi(apiPortStr); err == nil && port > 0 {
+			apiPort = port
+			log.Printf("🔌 使用数据库配置端口: %d (api_server_port)", apiPort)
+		}
+	} else {
+		log.Printf("🔌 使用默认端口: %d", apiPort)
 	}
 
 	// 创建并启动API服务器


### PR DESCRIPTION
## 📝 Description | 描述

**English:** Fix backend port configuration to prioritize `NOFX_BACKEND_PORT` environment variable. Previously, the program only read port from `config.json` (synced to database), causing `.env` configuration to be ignored.

**中文：** 修复后端端口配置，优先读取 `NOFX_BACKEND_PORT` 环境变量。之前程序只从 `config.json` 读取端口（同步到数据库），导致 `.env` 中的配置被忽略。

---

## 🎯 Type of Change | 变更类型

- [x] 🐛 Bug fix | 修复 Bug
- [ ] ✨ New feature | 新功能
- [ ] 💥 Breaking change | 破坏性变更
- [ ] 📝 Documentation update | 文档更新
- [ ] 🎨 Code style update | 代码样式更新
- [ ] ♻️ Refactoring | 重构
- [ ] ⚡ Performance improvement | 性能优化
- [ ] ✅ Test update | 测试更新
- [ ] 🔧 Build/config change | 构建/配置变更
- [ ] 🔒 Security fix | 安全修复

---

## 🔗 Related Issues | 相关 Issue

- Fixes: User reported that modifying `NOFX_BACKEND_PORT` in `.env` doesn't take effect when running `go run main.go`

---

## 📋 Changes Made | 具体变更

**English:**
- Implemented three-tier priority for port configuration: Environment Variable > Database Config > Default Value
- Added `NOFX_BACKEND_PORT` environment variable support
- Added detailed logging to show port source (env/database/default)
- Maintained backward compatibility with existing config.json configuration

**中文：**
- 实现三级优先级端口配置：环境变量 > 数据库配置 > 默认值
- 添加 `NOFX_BACKEND_PORT` 环境变量支持
- 添加详细日志输出，显示端口来源（环境变量/数据库/默认值）
- 保持与现有 config.json 配置的向后兼容性

---

## 🧪 Testing | 测试

- [x] Tested locally | 本地测试通过
- [x] Tests pass | 测试通过
- [x] Verified no existing functionality broke | 确认没有破坏现有功能

**Test Results:**
- ✅ Set `NOFX_BACKEND_PORT=18080` in `.env`, program correctly uses port 18080
- ✅ Log output: `🔌 使用环境变量端口: 18080 (NOFX_BACKEND_PORT)`
- ✅ Without env variable, falls back to database config or default 8080
- ✅ No port conflict when running with custom port

---

## ✅ Checklist | 检查清单

### Code Quality | 代码质量
- [x] Code follows project style | 代码遵循项目风格
- [x] Self-review completed | 已完成代码自查
- [x] Comments added for complex logic | 已添加必要注释

### Documentation | 文档
- [ ] Updated relevant documentation | 已更新相关文档
  - *Note: No documentation update needed as this fixes existing .env behavior*

### Git
- [x] Commits follow conventional format | 提交遵循 Conventional Commits 格式
- [x] Rebased on latest `dev` branch | 已 rebase 到最新 `dev` 分支
- [x] No merge conflicts | 无合并冲突

---

## 📚 Additional Notes | 补充说明

**English:** This change follows the 12-factor app best practices by prioritizing environment variables for configuration. It allows users to easily configure different ports for different deployment environments without modifying code or config files.

**中文：** 此修改遵循 12-factor app 最佳实践，优先使用环境变量进行配置。允许用户在不同部署环境中轻松配置不同端口，无需修改代码或配置文件。

**Code Changes:**
- Modified `main.go` lines 319-338
- Added environment variable reading logic with validation
- Added informative log messages for debugging

---

**By submitting this PR, I confirm | 提交此 PR，我确认：**

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) | 已阅读贡献指南
- [x] I agree to the [Code of Conduct](../CODE_OF_CONDUCT.md) | 同意行为准则
- [x] My contribution is licensed under AGPL-3.0 | 贡献遵循 AGPL-3.0 许可证

---

🌟 **Thank you for your contribution! | 感谢你的贡献！**
