### PR TITLE
fix(core logic): 修复 AI 决策时收到的持仓盈亏百分比未考虑杠杆

### DIFF
--- a/trader/auto_trader.go
+++ b/trader/auto_trader.go
@@ -622,14 +622,6 @@ func (at *AutoTrader) buildTradingContext() (*decision.Context, error) {
 		unrealizedPnl := pos["unRealizedProfit"].(float64)
 		liquidationPrice := pos["liquidationPrice"].(float64)
 
-		// 计算盈亏百分比
-		pnlPct := 0.0
-		if side == "long" {
-			pnlPct = ((markPrice - entryPrice) / entryPrice) * 100
-		} else {
-			pnlPct = ((entryPrice - markPrice) / entryPrice) * 100
-		}
-
 		// 计算占用保证金（估算）
 		leverage := 10 // 默认值，实际应该从持仓信息获取
 		if lev, ok := pos["leverage"].(float64); ok {
@@ -637,6 +629,9 @@ func (at *AutoTrader) buildTradingContext() (*decision.Context, error) {
 		}
 		marginUsed := (quantity * markPrice) / float64(leverage)
 		totalMarginUsed += marginUsed
+
+		// 计算盈亏百分比（基于保证金，考虑杠杆）
+		pnlPct := calculatePnLPercentage(unrealizedPnl, marginUsed)
 
 		// 跟踪持仓首次出现时间
 		posKey := symbol + "_" + side
@@ -1376,11 +1371,7 @@ func (at *AutoTrader) GetPositions() ([]map[string]interface{}, error) {
 		marginUsed := (quantity * markPrice) / float64(leverage)
 
 		// 计算盈亏百分比（基于保证金）
-		// 收益率 = 未实现盈亏 / 保证金 × 100%
-		pnlPct := 0.0
-		if marginUsed > 0 {
-			pnlPct = (unrealizedPnl / marginUsed) * 100
-		}
+		pnlPct := calculatePnLPercentage(unrealizedPnl, marginUsed)
 
 		result = append(result, map[string]interface{}{
 			"symbol":             symbol,
@@ -1397,6 +1388,15 @@ func (at *AutoTrader) GetPositions() ([]map[string]interface{}, error) {
 	}
 
 	return result, nil
+}
+
+// calculatePnLPercentage 计算盈亏百分比（基于保证金，自动考虑杠杆）
+// 收益率 = 未实现盈亏 / 保证金 × 100%
+func calculatePnLPercentage(unrealizedPnl, marginUsed float64) float64 {
+	if marginUsed > 0 {
+		return (unrealizedPnl / marginUsed) * 100
+	}
+	return 0.0
 }
 
 // sortDecisionsByPriority 对决策排序：先平仓，再开仓，最后hold/wait

--- a/trader/auto_trader_test.go
+++ b/trader/auto_trader_test.go
@@ -1,0 +1,118 @@
+package trader
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCalculatePnLPercentage(t *testing.T) {
+	tests := []struct {
+		name           string
+		unrealizedPnl  float64
+		marginUsed     float64
+		expected       float64
+	}{
+		{
+			name:           "正常盈利 - 10倍杠杆",
+			unrealizedPnl:  100.0,  // 盈利 100 USDT
+			marginUsed:     1000.0, // 保证金 1000 USDT
+			expected:       10.0,   // 10% 收益率
+		},
+		{
+			name:           "正常亏损 - 10倍杠杆",
+			unrealizedPnl:  -50.0,  // 亏损 50 USDT
+			marginUsed:     1000.0, // 保证金 1000 USDT
+			expected:       -5.0,   // -5% 收益率
+		},
+		{
+			name:           "高杠杆盈利 - 价格上涨1%，20倍杠杆",
+			unrealizedPnl:  200.0,  // 盈利 200 USDT
+			marginUsed:     1000.0, // 保证金 1000 USDT
+			expected:       20.0,   // 20% 收益率
+		},
+		{
+			name:           "保证金为0 - 边界情况",
+			unrealizedPnl:  100.0,
+			marginUsed:     0.0,
+			expected:       0.0, // 应该返回 0 而不是除以零错误
+		},
+		{
+			name:           "负保证金 - 边界情况",
+			unrealizedPnl:  100.0,
+			marginUsed:     -1000.0,
+			expected:       0.0, // 应该返回 0（异常情况）
+		},
+		{
+			name:           "盈亏为0",
+			unrealizedPnl:  0.0,
+			marginUsed:     1000.0,
+			expected:       0.0,
+		},
+		{
+			name:           "小额交易",
+			unrealizedPnl:  0.5,
+			marginUsed:     10.0,
+			expected:       5.0,
+		},
+		{
+			name:           "大额盈利",
+			unrealizedPnl:  5000.0,
+			marginUsed:     10000.0,
+			expected:       50.0,
+		},
+		{
+			name:           "极小保证金",
+			unrealizedPnl:  1.0,
+			marginUsed:     0.01,
+			expected:       10000.0, // 100倍收益率
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculatePnLPercentage(tt.unrealizedPnl, tt.marginUsed)
+
+			// 使用精度比较，避免浮点数误差
+			if math.Abs(result-tt.expected) > 0.0001 {
+				t.Errorf("calculatePnLPercentage(%v, %v) = %v, want %v",
+					tt.unrealizedPnl, tt.marginUsed, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestCalculatePnLPercentage_RealWorldScenarios 真实场景测试
+func TestCalculatePnLPercentage_RealWorldScenarios(t *testing.T) {
+	t.Run("BTC 10倍杠杆，价格上涨2%", func(t *testing.T) {
+		// 开仓：1000 USDT 保证金，10倍杠杆 = 10000 USDT 仓位
+		// 价格上涨 2% = 200 USDT 盈利
+		// 收益率 = 200 / 1000 = 20%
+		result := calculatePnLPercentage(200.0, 1000.0)
+		expected := 20.0
+		if math.Abs(result-expected) > 0.0001 {
+			t.Errorf("BTC场景: got %v, want %v", result, expected)
+		}
+	})
+
+	t.Run("ETH 5倍杠杆，价格下跌3%", func(t *testing.T) {
+		// 开仓：2000 USDT 保证金，5倍杠杆 = 10000 USDT 仓位
+		// 价格下跌 3% = -300 USDT 亏损
+		// 收益率 = -300 / 2000 = -15%
+		result := calculatePnLPercentage(-300.0, 2000.0)
+		expected := -15.0
+		if math.Abs(result-expected) > 0.0001 {
+			t.Errorf("ETH场景: got %v, want %v", result, expected)
+		}
+	})
+
+	t.Run("SOL 20倍杠杆，价格上涨0.5%", func(t *testing.T) {
+		// 开仓：500 USDT 保证金，20倍杠杆 = 10000 USDT 仓位
+		// 价格上涨 0.5% = 50 USDT 盈利
+		// 收益率 = 50 / 500 = 10%
+		result := calculatePnLPercentage(50.0, 500.0)
+		expected := 10.0
+		if math.Abs(result-expected) > 0.0001 {
+			t.Errorf("SOL场景: got %v, want %v", result, expected)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

修复 `buildTradingContext` 函数中传递给 AI 的持仓盈亏百分比计算错误。之前的计算只考虑了价格变化百分比，没有考虑杠杆的影响，导致 AI 收到的数据不准确。

## Changes

- 修复 `buildTradingContext` 中的盈亏百分比计算逻辑
- 抽取公共函数 `calculatePnLPercentage`（基于保证金计算，自动考虑杠杆）
- 重构 `GetPositions` 使用新的公共函数，确保一致性
- 添加 12 个单元测试覆盖各种场景

## Bug Impact

**问题**: 10 倍杠杆，价格上涨 1%，AI 收到的盈亏百分比是 1%，但实际应该是 10%

**原因**: 使用了错误的计算公式
```go
// 错误的计算（只考虑价格变化）
pnlPct = ((markPrice - entryPrice) / entryPrice) * 100
```

**修复**: 改为基于保证金计算
```go
// 正确的计算（自动考虑杠杆）
pnlPct = (unrealizedPnl / marginUsed) * 100
```

## Test Plan

- ✅ 创建了 `trader/auto_trader_test.go` 包含 12 个测试用例
- ✅ 覆盖正常盈利/亏损、高杠杆、边界情况
- ✅ 包含 BTC/ETH/SOL 真实场景测试
- ✅ 所有测试通过

## Related Issues

Fixes #818

## Notes

- PR #636 修复了账户余额计算和 `GetPositions` 的盈亏百分比，但遗漏了 `buildTradingContext`
- 本 PR 补充修复 `buildTradingContext`，并抽取公共函数避免未来重复错误