### PR TITLE
fix(trader):should not load all user traders when create/update trader

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -626,9 +626,9 @@ func (s *Server) handleCreateTrader(c *gin.Context) {
 	}
 
 	// 立即将新交易员加载到TraderManager中
-	err = s.traderManager.LoadUserTraders(s.database, userID)
+	err = s.traderManager.LoadTraderByID(s.database, userID, traderID)
 	if err != nil {
-		log.Printf("⚠️ 加载用户交易员到内存失败: %v", err)
+		log.Printf("⚠️ 加载交易员到内存失败: %v", err)
 		// 这里不返回错误，因为交易员已经成功创建到数据库
 	}
 
@@ -746,9 +746,9 @@ func (s *Server) handleUpdateTrader(c *gin.Context) {
 	}
 
 	// 重新加载交易员到内存
-	err = s.traderManager.LoadUserTraders(s.database, userID)
+	err = s.traderManager.LoadTraderByID(s.database, userID, traderID)
 	if err != nil {
-		log.Printf("⚠️ 重新加载用户交易员到内存失败: %v", err)
+		log.Printf("⚠️ 重新加载交易员到内存失败: %v", err)
 	}
 
 	log.Printf("✓ 更新交易员成功: %s (模型: %s, 交易所: %s)", req.Name, req.AIModelID, req.ExchangeID)
@@ -967,7 +967,7 @@ func (s *Server) handleSyncBalance(c *gin.Context) {
 		actualBalance = totalBalance
 	} else {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "无法获取可用余额"})
-		return
+				return
 	}
 
 	oldBalance := traderConfig.InitialBalance
@@ -991,9 +991,9 @@ func (s *Server) handleSyncBalance(c *gin.Context) {
 	}
 
 	// 重新加载交易员到内存
-	err = s.traderManager.LoadUserTraders(s.database, userID)
+	err = s.traderManager.LoadTraderByID(s.database, userID, traderID)
 	if err != nil {
-		log.Printf("⚠️ 重新加载用户交易员到内存失败: %v", err)
+		log.Printf("⚠️ 重新加载交易员到内存失败: %v", err)
 	}
 
 	log.Printf("✅ 已同步余额: %.2f → %.2f USDT (%s %.2f%%)", oldBalance, actualBalance, changeType, changePercent)


### PR DESCRIPTION
# Pull Request | PR 提交
---

## 📝 Description | 描述

**English:** ｜ **中文：**

添加了 LoadTraderByID 方法，专门用于加载单个交易员到内存,
优化前（使用 LoadUserTraders）

  创建1个交易员
    ├─ 查询该用户的所有交易员（假设100个）
    ├─ 查询所有AI模型配置
    ├─ 查询所有交易所配置
    ├─ 遍历100个交易员（99次跳过）
    └─ 持有全局锁时间：~2000ms

  优化后（使用 LoadTraderByID）

  创建1个交易员
    ├─ 查询该用户的所有交易员（找到目标后立即停止）
    ├─ 查询所有AI模型配置
    ├─ 查询所有交易所配置
    ├─ 只处理1个交易员
    └─ 持有全局锁时间：~40ms

---

## 🎯 Type of Change | 变更类型

- [ ] ⚡ Performance improvement | 性能优化

---


## 🧪 Testing | 测试

- [ ] Tested locally | 本地测试通过
- [ ] Tests pass | 测试通过
- [ ] Verified no existing functionality broke | 确认没有破坏现有功能


---

🌟 **Thank you for your contribution! | 感谢你的贡献！**
