### PR TITLE
chore: fix go formatting for test files

### DIFF
--- a/decision/prompt_manager_test.go
+++ b/decision/prompt_manager_test.go
@@ -29,7 +29,7 @@ func TestPromptManager_LoadTemplates(t *testing.T) {
 		{
 			name: "加载多个模板文件",
 			setupFiles: map[string]string{
-				"default.txt":     "默认策略",
+				"default.txt":      "默认策略",
 				"conservative.txt": "保守策略",
 				"aggressive.txt":   "激进策略",
 			},
@@ -130,15 +130,15 @@ func TestPromptManager_GetTemplate(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		templateName   string
-		expectError    bool
+		name            string
+		templateName    string
+		expectError     bool
 		expectedContent string
 	}{
 		{
-			name:           "获取存在的模板",
-			templateName:   "default",
-			expectError:    false,
+			name:            "获取存在的模板",
+			templateName:    "default",
+			expectError:     false,
 			expectedContent: "默认策略内容",
 		},
 		{
@@ -225,7 +225,7 @@ func TestPromptManager_ReloadTemplates(t *testing.T) {
 func TestPromptManager_GetAllTemplateNames(t *testing.T) {
 	pm := NewPromptManager()
 	pm.templates = map[string]*PromptTemplate{
-		"default":     {Name: "default", Content: "默认策略"},
+		"default":      {Name: "default", Content: "默认策略"},
 		"conservative": {Name: "conservative", Content: "保守策略"},
 		"aggressive":   {Name: "aggressive", Content: "激进策略"},
 	}

--- a/trader/hyperliquid_trader_race_test.go
+++ b/trader/hyperliquid_trader_race_test.go
@@ -123,7 +123,7 @@ func TestGetSzDecimals_ValidMeta(t *testing.T) {
 	}
 
 	tests := []struct {
-		coin            string
+		coin             string
 		expectedDecimals int
 	}{
 		{"BTC", 5},


### PR DESCRIPTION
## 📝 Description | 描述

**中文：**

修復測試文件的 Go 代碼格式問題，消除 CI 中的格式化警告。

**English:**

Fix Go code formatting issues in test files to eliminate CI formatting warnings.

---

## 🎯 Type of Change | 變更類型

- [ ] 🐛 Bug fix | 修復 Bug
- [ ] ✨ New feature | 新功能
- [ ] 💥 Breaking change | 破壞性變更
- [ ] ♻️ Refactoring | 重構
- [ ] ⚡ Performance improvement | 性能優化
- [ ] 🔒 Security fix | 安全修復
- [x] 🔧 Build/config change | 構建/配置變更

---

## 🔗 Related Issues | 相關 Issue

N/A - Code quality improvement

---

## 📋 Changes Made | 具體變更

### Background | 背景

每次 CI 都顯示這個 advisory 警告（雖然不阻止合併）：

```
⚠️ Go Formatting: Needs formatting

Files needing formatting:
- decision/prompt_manager_test.go
- trader/hyperliquid_trader_race_test.go
```

### Root Cause | 根本原因

這兩個文件在提交時沒有運行 `go fmt`：

1. **decision/prompt_manager_test.go**
   - 最後修改：PR #833 (feat: auto-reload prompt templates)
   - 問題：struct 字段對齊不一致（tab/空格混用）

2. **trader/hyperliquid_trader_race_test.go**
   - 最後修改：PR #796 (fix: add mutex to prevent race condition)
   - 問題：struct 字段對齊不一致

### Fix | 修復

運行標準 Go 格式化工具：

```bash
go fmt ./decision/prompt_manager_test.go
go fmt ./trader/hyperliquid_trader_race_test.go
```

### Changes Detail | 變更詳情

**decision/prompt_manager_test.go** (4 處修正):
```diff
 tests := []struct {
-    name           string
-    templateName   string
-    expectError    bool
+    name            string
+    templateName    string
+    expectError     bool
     expectedContent string
 }
```

**trader/hyperliquid_trader_race_test.go** (1 處修正):
```diff
 tests := []struct {
-    coin            string
+    coin             string
     expectedDecimals int
 }
```

---

## 🧪 Testing | 測試

### Test Environment | 測試環境
- **OS | 操作系統:** macOS Darwin 24.5.0
- **Go Version | Go 版本:** go1.23

### Test Results | 測試結果

**Before | 修復前:**
```bash
$ go fmt ./decision/prompt_manager_test.go
decision/prompt_manager_test.go  # 需要格式化

$ go fmt ./trader/hyperliquid_trader_race_test.go
trader/hyperliquid_trader_race_test.go  # 需要格式化
```

**After | 修復後:**
```bash
$ go fmt ./decision/prompt_manager_test.go
# 無輸出（已格式化）

$ go fmt ./trader/hyperliquid_trader_race_test.go
# 無輸出（已格式化）
```

### Manual Testing | 手動測試
- [x] Code compiles successfully | 代碼編譯成功
- [x] Ran `go fmt` | 已運行 `go fmt`
- [x] No functional changes | 無功能變更
- [x] Tests still pass | 測試仍然通過

---

## 🔒 Security Considerations | 安全考慮

- [x] N/A (code formatting only) | 不適用（僅格式化）

---

## ⚡ Performance Impact | 性能影響

- [x] No performance impact | 無性能影響

---

## ✅ Checklist | 檢查清單

### Code Quality | 代碼質量
- [x] Code follows project style | 代碼遵循項目風格
- [x] Self-review completed | 已完成代碼自查
- [x] Code compiles successfully | 代碼編譯成功
- [x] Ran `go fmt` | 已運行 `go fmt`

### Git
- [x] Commits follow conventional format | 提交遵循 Conventional Commits 格式
- [x] Rebased on latest `dev` branch | 已 rebase 到最新 `dev` 分支
- [x] No merge conflicts | 無合併衝突

---

## 📚 Additional Notes | 補充說明

**中文：**

### 影響範圍

這是一個純格式化修復，**不改變任何業務邏輯**：
- ✅ 只修改空格/tab 對齊
- ✅ 不修改任何代碼邏輯
- ✅ 不修改測試用例
- ✅ 所有現有測試仍然通過

### 好處

修復後，所有後續 PR 的 CI 將不再顯示這個格式化警告，提升開發體驗。

---

**By submitting this PR, I confirm | 提交此 PR，我確認：**

- [x] I have read the [Contributing Guidelines](../../CONTRIBUTING.md) | 已閱讀貢獻指南
- [x] I agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md) | 同意行為準則
- [x] My contribution is licensed under AGPL-3.0 | 貢獻遵循 AGPL-3.0 許可證

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>