### PR TITLE
feat: 實現 Smart Fallback 智能回退機制解決保證金不足問題

### DIFF
--- a/config/database.go
+++ b/config/database.go
@@ -486,6 +486,10 @@ type TraderRecord struct {
 	OverrideBasePrompt   bool      `json:"override_base_prompt"`   // 是否覆盖基础prompt
 	SystemPromptTemplate string    `json:"system_prompt_template"` // 系统提示词模板名称
 	IsCrossMargin        bool      `json:"is_cross_margin"`        // 是否为全仓模式（true=全仓，false=逐仓）
+	TakerFeeRate         float64   `json:"taker_fee_rate"`         // Taker fee rate, default 0.0004
+	MakerFeeRate         float64   `json:"maker_fee_rate"`         // Maker fee rate, default 0.0002
+	EnableSmartFallback  bool      `json:"enable_smart_fallback"`  // 启用智能回退（保证金不足时自动调整）
+	MinLeverage          int       `json:"min_leverage"`           // 最低可降至的杠杆倍数（默认1x）
 	CreatedAt            time.Time `json:"created_at"`
 	UpdatedAt            time.Time `json:"updated_at"`
 }

--- a/manager/trader_manager.go
+++ b/manager/trader_manager.go
@@ -212,6 +212,24 @@ func (tm *TraderManager) addTraderFromDB(traderCfg *config.TraderRecord, aiModel
 		log.Printf("✓ 交易员 %s 启用 COIN POOL 信号源: %s", traderCfg.Name, coinPoolURL)
 	}
 
+	// 向后兼容：为旧数据设置默认值
+	takerFeeRate := traderCfg.TakerFeeRate
+	if takerFeeRate == 0 {
+		takerFeeRate = 0.0004 // 默认 0.04%
+	}
+	makerFeeRate := traderCfg.MakerFeeRate
+	if makerFeeRate == 0 {
+		makerFeeRate = 0.0002 // 默认 0.02%
+	}
+	enableSmartFallback := traderCfg.EnableSmartFallback
+	if !traderCfg.EnableSmartFallback && traderCfg.MinLeverage == 0 {
+		enableSmartFallback = true // 旧数据默认启用
+	}
+	minLeverage := traderCfg.MinLeverage
+	if minLeverage == 0 {
+		minLeverage = 1 // 默认最低1x
+	}
+
 	// 构建AutoTraderConfig
 	traderConfig := trader.AutoTraderConfig{
 		ID:                    traderCfg.ID,
@@ -239,6 +257,10 @@ func (tm *TraderManager) addTraderFromDB(traderCfg *config.TraderRecord, aiModel
 		DefaultCoins:          defaultCoins,
 		TradingCoins:          tradingCoins,
 		SystemPromptTemplate:  traderCfg.SystemPromptTemplate, // 系统提示词模板
+		TakerFeeRate:          takerFeeRate,                   // Taker 费率
+		MakerFeeRate:          makerFeeRate,                   // Maker 费率
+		EnableSmartFallback:   enableSmartFallback,            // Smart Fallback 配置
+		MinLeverage:           minLeverage,                    // 最低杠杆
 	}
 
 	// 根据交易所类型设置API密钥
@@ -319,6 +341,24 @@ func (tm *TraderManager) AddTraderFromDB(traderCfg *config.TraderRecord, aiModel
 		log.Printf("✓ 交易员 %s 启用 COIN POOL 信号源: %s", traderCfg.Name, coinPoolURL)
 	}
 
+	// 向后兼容：为旧数据设置默认值
+	takerFeeRate := traderCfg.TakerFeeRate
+	if takerFeeRate == 0 {
+		takerFeeRate = 0.0004 // 默认 0.04%
+	}
+	makerFeeRate := traderCfg.MakerFeeRate
+	if makerFeeRate == 0 {
+		makerFeeRate = 0.0002 // 默认 0.02%
+	}
+	enableSmartFallback := traderCfg.EnableSmartFallback
+	if !traderCfg.EnableSmartFallback && traderCfg.MinLeverage == 0 {
+		enableSmartFallback = true // 旧数据默认启用
+	}
+	minLeverage := traderCfg.MinLeverage
+	if minLeverage == 0 {
+		minLeverage = 1 // 默认最低1x
+	}
+
 	// 构建AutoTraderConfig
 	traderConfig := trader.AutoTraderConfig{
 		ID:                    traderCfg.ID,
@@ -345,6 +385,10 @@ func (tm *TraderManager) AddTraderFromDB(traderCfg *config.TraderRecord, aiModel
 		IsCrossMargin:         traderCfg.IsCrossMargin,
 		DefaultCoins:          defaultCoins,
 		TradingCoins:          tradingCoins,
+		TakerFeeRate:          takerFeeRate,        // Taker 费率
+		MakerFeeRate:          makerFeeRate,        // Maker 费率
+		EnableSmartFallback:   enableSmartFallback, // Smart Fallback 配置
+		MinLeverage:           minLeverage,         // 最低杠杆
 	}
 
 	// 根据交易所类型设置API密钥
@@ -1021,6 +1065,24 @@ func (tm *TraderManager) loadSingleTrader(traderCfg *config.TraderRecord, aiMode
 		log.Printf("✓ 交易员 %s 启用 COIN POOL 信号源: %s", traderCfg.Name, coinPoolURL)
 	}
 
+	// 向后兼容：为旧数据设置默认值
+	takerFeeRate := traderCfg.TakerFeeRate
+	if takerFeeRate == 0 {
+		takerFeeRate = 0.0004 // 默认 0.04%
+	}
+	makerFeeRate := traderCfg.MakerFeeRate
+	if makerFeeRate == 0 {
+		makerFeeRate = 0.0002 // 默认 0.02%
+	}
+	enableSmartFallback := traderCfg.EnableSmartFallback
+	if !traderCfg.EnableSmartFallback && traderCfg.MinLeverage == 0 {
+		enableSmartFallback = true // 旧数据默认启用
+	}
+	minLeverage := traderCfg.MinLeverage
+	if minLeverage == 0 {
+		minLeverage = 1 // 默认最低1x
+	}
+
 	// 构建AutoTraderConfig
 	traderConfig := trader.AutoTraderConfig{
 		ID:                   traderCfg.ID,
@@ -1043,6 +1105,10 @@ func (tm *TraderManager) loadSingleTrader(traderCfg *config.TraderRecord, aiMode
 		TradingCoins:         tradingCoins,
 		SystemPromptTemplate: traderCfg.SystemPromptTemplate, // 系统提示词模板
 		HyperliquidTestnet:   exchangeCfg.Testnet,            // Hyperliquid测试网
+		TakerFeeRate:         takerFeeRate,                   // Taker 费率
+		MakerFeeRate:         makerFeeRate,                   // Maker 费率
+		EnableSmartFallback:  enableSmartFallback,            // Smart Fallback 配置
+		MinLeverage:          minLeverage,                    // 最低杠杆
 	}
 
 	// 根据交易所类型设置API密钥

--- a/trader/smart_fallback_test.go
+++ b/trader/smart_fallback_test.go
@@ -1,0 +1,238 @@
+package trader
+
+import (
+	"testing"
+)
+
+// TestTrySmartFallback 测试 Smart Fallback 机制
+func TestTrySmartFallback(t *testing.T) {
+	tests := []struct {
+		name              string
+		originalSize      float64
+		originalLeverage  int
+		availableBalance  float64
+		minLeverage       int
+		takerFeeRate      float64
+		expectSuccess     bool
+		expectedSize      float64
+		expectedLeverage  int
+		expectedAdjustLen int // 预期调整记录数量
+	}{
+		{
+			name:              "微调持仓98%成功",
+			originalSize:      100.0,
+			originalLeverage:  5,
+			availableBalance:  20.0, // 原始需要 20.04，98% 需要 19.64
+			minLeverage:       1,
+			takerFeeRate:      0.0004,
+			expectSuccess:     true,
+			expectedSize:      98.0,
+			expectedLeverage:  5,
+			expectedAdjustLen: 1,
+		},
+		{
+			name:              "微调持仓95%成功",
+			originalSize:      100.0,
+			originalLeverage:  5,
+			availableBalance:  19.2, // 原始需要 20.04，95% 需要 19.04
+			minLeverage:       1,
+			takerFeeRate:      0.0004,
+			expectSuccess:     true,
+			expectedSize:      95.0,
+			expectedLeverage:  5,
+			expectedAdjustLen: 1,
+		},
+		{
+			name:              "微调持仓90%成功",
+			originalSize:      100.0,
+			originalLeverage:  5,
+			availableBalance:  18.2, // 原始需要 20.04，90% 需要 18.04
+			minLeverage:       1,
+			takerFeeRate:      0.0004,
+			expectSuccess:     true,
+			expectedSize:      90.0,
+			expectedLeverage:  5,
+			expectedAdjustLen: 1,
+		},
+		{
+			name:              "所有方法都失败",
+			originalSize:      100.0,
+			originalLeverage:  5,
+			availableBalance:  10.0, // 远不够
+			minLeverage:       1,
+			takerFeeRate:      0.0004,
+			expectSuccess:     false,
+			expectedSize:      100.0,
+			expectedLeverage:  5,
+			expectedAdjustLen: 0,
+		},
+		{
+			name:              "边界情况：用户报告的99.67_USDT案例",
+			originalSize:      498.0, // 5x BTC at ~100k = ~500 USDT
+			originalLeverage:  5,
+			availableBalance:  99.67, // 原始需要 99.80，差 0.13
+			minLeverage:       1,
+			takerFeeRate:      0.0004,
+			expectSuccess:     true,
+			expectedSize:      498.0 * 0.98, // 98% 应该成功
+			expectedLeverage:  5,
+			expectedAdjustLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 创建测试用的 AutoTrader
+			at := &AutoTrader{
+				config: AutoTraderConfig{
+					MinLeverage:  tt.minLeverage,
+					TakerFeeRate: tt.takerFeeRate,
+				},
+			}
+
+			// 调用 trySmartFallback
+			adjustedSize, adjustedLev, success, adjustments := at.trySmartFallback(
+				tt.originalSize,
+				tt.originalLeverage,
+				tt.availableBalance,
+				"BTCUSDT",
+				100000.0, // BTC 价格
+			)
+
+			// 验证成功状态
+			if success != tt.expectSuccess {
+				t.Errorf("success = %v, want %v", success, tt.expectSuccess)
+			}
+
+			// 如果预期成功，验证调整结果
+			if tt.expectSuccess {
+				const epsilon = 0.01 // 允许小数点后2位的误差
+				sizeDiff := adjustedSize - tt.expectedSize
+				if sizeDiff < -epsilon || sizeDiff > epsilon {
+					t.Errorf("adjustedSize = %.2f, want %.2f (diff: %.4f)", adjustedSize, tt.expectedSize, sizeDiff)
+				}
+				if adjustedLev != tt.expectedLeverage {
+					t.Errorf("adjustedLeverage = %d, want %d", adjustedLev, tt.expectedLeverage)
+				}
+
+				// 验证最终的保证金计算
+				requiredMargin := adjustedSize / float64(adjustedLev)
+				estimatedFee := adjustedSize * tt.takerFeeRate
+				totalRequired := requiredMargin + estimatedFee
+
+				if totalRequired > tt.availableBalance {
+					t.Errorf("最终仍然保证金不足: 需要 %.2f, 可用 %.2f",
+						totalRequired, tt.availableBalance)
+				}
+
+				// 验证调整记录数量
+				if len(adjustments) != tt.expectedAdjustLen {
+					t.Errorf("adjustments 数量 = %d, want %d (记录: %v)",
+						len(adjustments), tt.expectedAdjustLen, adjustments)
+				}
+
+				t.Logf("✓ %s: 调整成功", tt.name)
+				for i, adj := range adjustments {
+					t.Logf("  %d. %s", i+1, adj)
+				}
+				t.Logf("  最终: 持仓 %.2f USDT, 杠杆 %dx, 需要 %.2f USDT",
+					adjustedSize, adjustedLev, totalRequired)
+			} else {
+				t.Logf("✓ %s: 按预期失败", tt.name)
+			}
+		})
+	}
+}
+
+// TestSmartFallbackEdgeCases 测试边界情况
+func TestSmartFallbackEdgeCases(t *testing.T) {
+	tests := []struct {
+		name             string
+		originalSize     float64
+		originalLeverage int
+		availableBalance float64
+		minLeverage      int
+		takerFeeRate     float64
+		expectSuccess    bool
+		description      string
+	}{
+		{
+			name:             "零可用余额",
+			originalSize:     100.0,
+			originalLeverage: 5,
+			availableBalance: 0.0,
+			minLeverage:      1,
+			takerFeeRate:     0.0004,
+			expectSuccess:    false,
+			description:      "完全没有可用余额",
+		},
+		{
+			name:             "极小持仓1_USDT",
+			originalSize:     1.0,
+			originalLeverage: 5,
+			availableBalance: 0.19, // 需要 0.2004
+			minLeverage:      1,
+			takerFeeRate:     0.0004,
+			expectSuccess:    true,
+			description:      "极小持仓也能调整",
+		},
+		{
+			name:             "极高杠杆100x",
+			originalSize:     100.0,
+			originalLeverage: 100,
+			availableBalance: 1.0, // 100x 只需要 1.04
+			minLeverage:      1,
+			takerFeeRate:     0.0004,
+			expectSuccess:    true,
+			description:      "极高杠杆不需要调整",
+		},
+		{
+			name:             "1x杠杆无法再降",
+			originalSize:     100.0,
+			originalLeverage: 1,
+			availableBalance: 90.0, // 1x 需要 100.04
+			minLeverage:      1,
+			takerFeeRate:     0.0004,
+			expectSuccess:    true, // 可以微调持仓
+			description:      "1x 杠杆只能微调持仓",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			at := &AutoTrader{
+				config: AutoTraderConfig{
+					MinLeverage:  tt.minLeverage,
+					TakerFeeRate: tt.takerFeeRate,
+				},
+			}
+
+			adjustedSize, adjustedLev, success, adjustments := at.trySmartFallback(
+				tt.originalSize,
+				tt.originalLeverage,
+				tt.availableBalance,
+				"BTCUSDT",
+				100000.0,
+			)
+
+			if success != tt.expectSuccess {
+				t.Errorf("%s: success = %v, want %v", tt.description, success, tt.expectSuccess)
+			}
+
+			if success {
+				requiredMargin := adjustedSize / float64(adjustedLev)
+				estimatedFee := adjustedSize * tt.takerFeeRate
+				totalRequired := requiredMargin + estimatedFee
+
+				if totalRequired > tt.availableBalance {
+					t.Errorf("%s: 最终保证金不足 (需要 %.4f > 可用 %.4f)",
+						tt.description, totalRequired, tt.availableBalance)
+				}
+
+				t.Logf("✓ %s: 成功 (调整: %v)", tt.description, adjustments)
+			} else {
+				t.Logf("✓ %s: 按预期失败", tt.description)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

修復生產環境中用戶遇到的保證金不足錯誤，實現三層智能回退策略自動調整持倉或杠杆。

### 問題背景
- **用戶報告**：成功入場但提示「保證金不足：需要 99.80 USDT（保證金 99.60 + 手續費 0.20），可用 99.67 USDT」
- **影響範圍**：當可用餘額與所需保證金相差極小時（如 0.13 USDT），訂單被拒絕
- **根本原因**：缺乏自動調整機制來應對微小的資金缺口

### 解決方案

實現 **Smart Fallback 智能回退機制**，自動嘗試三層調整策略：

1. **微調持倉（Step 1）**：嘗試將持倉調整為 98%, 95%, 90%，保持原杠杆不變
2. **降低杠杆（Step 2）**：從原杠杆 N-1 降至最低杠杆（默認 1x）
3. **組合策略（Step 3）**：使用最低杠杆 + 持倉微調（98%-80%）

### 新增配置字段

- `EnableSmartFallback` (bool): 啟用智能回退（**默認 true**）
- `MinLeverage` (int): 最低可降至的杠杆倍數（**默認 1x**）
- `TakerFeeRate` (float64): Taker 手續費率（默認 0.0004 即 0.04%）
- `MakerFeeRate` (float64): Maker 手續費率（默認 0.0002 即 0.02%）

### 核心實現

#### 1. config/database.go
- 添加 Smart Fallback 配置字段到 `TraderRecord` 結構體

#### 2. trader/auto_trader.go
- 實現 `trySmartFallback()` 核心算法（lines 760-824）
- 集成到 `OpenLong()` 和 `OpenShort()` 流程（lines 863-917, 990-1044）
- 保證金不足時自動觸發 Smart Fallback

#### 3. api/server.go
- `handleCreateTrader`: 為新交易員設置默認值
- `handleUpdateTrader`: 確保舊交易員自動獲得默認值（向後兼容）

#### 4. manager/trader_manager.go
- 在 `addTraderFromDB`, `AddTraderFromDB`, `loadSingleTrader` 三處添加配置
- 為舊數據設置默認值邏輯

#### 5. trader/smart_fallback_test.go
- 新增完整測試套件（**9 個測試案例全部通過**）
- 包含用戶報告的 99.67 USDT 實際案例

## Test plan

### ✅ 編譯測試
```bash
go fmt ./...
go build ./...
```

### ✅ 單元測試（9/9 通過）
```bash
go test -v nofx/trader -run "TestTrySmartFallback|TestSmartFallbackEdgeCases"
```

**測試覆蓋**：
- `TestTrySmartFallback`: 5/5 通過
  - 微調持倉 98%, 95%, 90% 成功
  - 所有方法都失敗的情況
  - **用戶報告的 99.67 USDT 案例**（498 USDT 持倉，5x 杠杆）
- `TestSmartFallbackEdgeCases`: 4/4 通過
  - 零可用餘額
  - 極小持倉 1 USDT
  - 極高杠杆 100x
  - 1x 杠杆無法再降（只能微調持倉）

### ✅ 向後兼容性
- 舊交易員自動獲得默認配置（EnableSmartFallback=true, MinLeverage=1）
- 不影響現有功能和數據結構

## 影響範圍

- **新增功能**：Smart Fallback 智能回退機制
- **向後兼容**：✅ 完全兼容
- **默認行為**：✅ 默認啟用，提升用戶體驗
- **性能影響**：⚡ 僅在保證金不足時觸發，無額外開銷

## 預期效果

- ✅ 自動解決微小的資金缺口問題
- ✅ 減少因保證金不足導致的訂單失敗
- ✅ 提升用戶體驗（自動調整 > 訂單失敗）
- ✅ 保持風險可控（最低杠杆和持倉調整幅度可配置）

🤖 Generated with [Claude Code](https://claude.com/claude-code)