### PR TITLE
fix: improve initial balance UX to prevent input overwrite (#629)

### DIFF
--- a/web/src/components/TraderConfigModal.tsx
+++ b/web/src/components/TraderConfigModal.tsx
@@ -440,7 +440,7 @@ export function TraderConfigModal({
                         }
                       }}
                       className="w-full px-3 py-2 bg-[#0B0E11] border border-[#2B3139] rounded text-[#EAECEF] focus:border-[#F0B90B] focus:outline-none"
-                      min="100"
+                      min="0.01"
                       step="0.01"
                     />
                     <p className="text-xs text-[#848E9C] mt-1">


### PR DESCRIPTION
## 問題描述

用戶可以手動輸入小於 100 的初始餘額值，但點擊數字輸入框的箭頭按鈕時，會立即將輸入覆寫為 100，造成困擾。

## 根本原因

- 輸入框設定了 `min="100"` 屬性
- 瀏覽器的箭頭按鈕會強制執行此最小值約束
- 手動輸入可以繞過約束
- 導致手動輸入和箭頭調整之間的行為不一致

## 解決方案

調整輸入框約束：
- `min`: 100 → 0.01 (允許彈性的輸入金額)

上游程式碼庫已經具備：
✅ `step="0.01"` (精細調整)
✅ `onBlur` 驗證 (自動調整 < 100 的值為 100)
✅ 說明行為的提示文字

## 優點

✅ 用戶可以不受干擾地輸入任何值
✅ 箭頭按鈕可以順暢地進行微調
✅ 小於 100 的值會在失去焦點時自動修正（而非輸入過程中）
✅ 最小化的代碼變更（1 個檔案，1 行）

## 測試

手動測試確認：
- 可以輸入 50、75、150 等值
- 箭頭按鈕以 0.01 為單位調整
- 失去焦點時，小於 100 的值會自動調整為 100
- 不再出現輸入被覆寫的問題

Fixes #629

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>