### PR TITLE
fix(web): fix 401 unauthorized redirect not working properly

### DIFF
--- a/web/src/components/TraderConfigModal.tsx
+++ b/web/src/components/TraderConfigModal.tsx
@@ -4,6 +4,7 @@ import { useLanguage } from '../contexts/LanguageContext'
 import { t } from '../i18n/translations'
 import { toast } from 'sonner'
 import { Pencil, Plus, X as IconX } from 'lucide-react'
+import { httpClient } from '../lib/httpClient'
 
 // 提取下划线后面的名称部分
 function getShortName(fullName: string): string {
@@ -114,7 +115,7 @@ export function TraderConfigModal({
   useEffect(() => {
     const fetchConfig = async () => {
       try {
-        const response = await fetch('/api/config')
+        const response = await httpClient.get('/api/config')
         const config = await response.json()
         if (config.default_coins) {
           setAvailableCoins(config.default_coins)
@@ -140,7 +141,7 @@ export function TraderConfigModal({
   useEffect(() => {
     const fetchPromptTemplates = async () => {
       try {
-        const response = await fetch('/api/prompt-templates')
+        const response = await httpClient.get('/api/prompt-templates')
         const data = await response.json()
         if (data.templates) {
           setPromptTemplates(data.templates)
@@ -198,18 +199,12 @@ export function TraderConfigModal({
         throw new Error('未登录，请先登录')
       }
 
-      const response = await fetch(
+      const response = await httpClient.get(
         `/api/account?trader_id=${traderData.trader_id}`,
         {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
+          Authorization: `Bearer ${token}`,
         }
       )
-
-      if (!response.ok) {
-        throw new Error('获取账户余额失败')
-      }
 
       const data = await response.json()
 

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -474,6 +474,7 @@ export const translations = {
     registrationFailed: 'Registration failed. Please try again.',
     verificationFailed:
       'OTP verification failed. Please check the code and try again.',
+    sessionExpired: 'Session expired, please login again',
     invalidCredentials: 'Invalid email or password',
     weak: 'Weak',
     medium: 'Medium',
@@ -1287,6 +1288,7 @@ export const translations = {
     loginFailed: '登录失败，请检查您的邮箱和密码。',
     registrationFailed: '注册失败，请重试。',
     verificationFailed: 'OTP 验证失败，请检查验证码后重试。',
+    sessionExpired: '登录已过期，请重新登录',
     invalidCredentials: '邮箱或密码错误',
     weak: '弱',
     medium: '中',


### PR DESCRIPTION

# Pull Request | PR 提交

---

## 📝 Description | 描述

**English:** ｜ **中文：**

**中文：**
<img width="1844" height="912" alt="image" src="https://github.com/user-attachments/assets/0a6f8af2-cf61-4b7a-b946-2afc6d937917" />

用户报告：当登录token过期后，页面的请求一直遇到401错误，但没有自动跳转到登录页面。用户只能看到重复的401错误提示，无法正常使用系统。

**English:**

Users reported that when the login token expires, API requests continuously encounter 401 errors without automatically redirecting to the login page. Users only see repeated 401 error messages and cannot use the system normally.

Testing result:

User was redirected to login page when session timeout:
<img width="1856" height="854" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/1e620a20-0045-4f37-bf94-846e7ba9bfc4" />

International user:
<img width="1796" height="881" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/4d1bbd18-ba7c-46d1-b363-6ee8eb8f9f45" />



---

## 🎯 Type of Change | 变更类型

- [ ] 🐛 Bug fix | 修复 Bug
---

## 🔗 Related Issues | 相关 Issue

- Closes # | 关闭 #984 
- Related to # | 相关 #

---

## 📋 Changes Made | 具体变更

**English:** ｜ **中文：**
-
-
1. **TraderConfigModal 绕过了拦截器**
   - 文件中有3处直接使用 `fetch()` 而不是 `httpClient`
   - 这些请求的401错误不会触发跳转逻辑

2. **setTimeout 导致跳转失败**
   - 原代码使用 1.5 秒延迟跳转，在此期间：
     - SWR 每10秒自动刷新可能触发新的401请求
     - 新请求因 `isHandling401=true` 只抛出错误，不会跳转
     - React 可能渲染错误页面，阻塞跳转执行

3. **throw Error 被 SWR 捕获**
   - `handleResponse` 抛出错误后被 SWR 捕获
   - SWR 设置 `tradersError` 状态
   - React 渲染错误页面，而不是跳转

**English:**

After thorough analysis, three main issues were identified:

1. **TraderConfigModal bypassed the interceptor**
   - 3 instances of direct `fetch()` calls instead of using `httpClient`
   - 401 errors from these requests don't trigger redirect logic

2. **setTimeout caused redirect failures**
   - Original code used 1.5 second delay, during which:
     - SWR's 10-second auto-refresh could trigger new 401 requests
     - New requests only throw errors due to `isHandling401=true`, no redirect
     - React might render error page, blocking redirect execution

3. **throw Error caught by SWR**
   - Errors thrown by `handleResponse` are caught by SWR
   - SWR sets `tradersError` state
   - React renders error page instead of redirecting

---
---

## 🧪 Testing | 测试

- [ ] Tested locally | 本地测试通过
- [ ] Tests pass | 测试通过
- [ ] Verified no existing functionality broke | 确认没有破坏现有功能

---

**By submitting this PR, I confirm | 提交此 PR，我确认：**

- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md) | 已阅读贡献指南
- [ ] I agree to the [Code of Conduct](../CODE_OF_CONDUCT.md) | 同意行为准则
- [ ] My contribution is licensed under AGPL-3.0 | 贡献遵循 AGPL-3.0 许可证

---

🌟 **Thank you for your contribution! | 感谢你的贡献！**
