### PR TITLE
fix(bybit): complete Bybit integration by adding API layer support

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -562,6 +562,11 @@ func (s *Server) handleCreateTrader(c *gin.Context) {
 				exchangeCfg.AsterSigner,
 				exchangeCfg.AsterPrivateKey,
 			)
+		case "bybit":
+			tempTrader = trader.NewBybitTrader(
+				exchangeCfg.APIKey,
+				exchangeCfg.SecretKey,
+			)
 		default:
 			log.Printf("⚠️ 不支持的交易所类型: %s，使用用户输入的初始资金", req.ExchangeID)
 		}
@@ -938,6 +943,11 @@ func (s *Server) handleSyncBalance(c *gin.Context) {
 			exchangeCfg.AsterSigner,
 			exchangeCfg.AsterPrivateKey,
 		)
+		case "bybit":
+			tempTrader = trader.NewBybitTrader(
+				exchangeCfg.APIKey,
+				exchangeCfg.SecretKey,
+			)
 	default:
 		c.JSON(http.StatusBadRequest, gin.H{"error": "不支持的交易所类型"})
 		return


### PR DESCRIPTION
## Problem

PR #1100 added Bybit Futures trader implementation but missed the API layer integration, causing:
- Unable to create Bybit traders (returns "unsupported exchange type" error)
- Cannot query Bybit account balance  
- Balance sync feature unavailable for Bybit users

## Root Cause

While PR #1100 successfully implemented:
- ✅ `trader/bybit_trader.go` - complete Bybit trader
- ✅ `manager/trader_manager.go` - API key configuration
- ✅ `trader/auto_trader.go` - Bybit case in AutoTrader
- ✅ `logger/decision_logger.go` - 0.055% fee rate

It missed the API server layer integration in `api/server.go`, which prevents users from actually using Bybit.

## Solution

Add Bybit case in two critical switch statements in `api/server.go`:

1. **`handleCreateTrader()`** (line ~565) - Balance query when creating a new trader
2. **`handleSyncBalance()`** (line ~946) - Manual balance sync functionality

Both locations now properly create a Bybit trader instance for balance queries:

```go
case "bybit":
    tempTrader = trader.NewBybitTrader(
        exchangeCfg.APIKey,
        exchangeCfg.SecretKey,
    )
```

## Testing

✅ Tested on local fork (the-dev-z/nofx, z-dev-v3 branch):
- Can successfully create Bybit trader
- Correctly queries Bybit account balance
- Balance sync functionality works as expected

## Impact

This fix completes the Bybit integration from PR #1100, enabling users to:
- Create Bybit trading bots
- Query real-time Bybit balances
- Sync initial balance from Bybit accounts

---

## 中文說明

### 問題描述

PR #1100 實現了 Bybit Futures 交易器，但**遺漏了 API 層的集成**，導致：
- ❌ 無法創建 Bybit 交易機器人（返回 "unsupported exchange type" 錯誤）
- ❌ 無法查詢 Bybit 帳戶餘額
- ❌ Bybit 用戶無法使用餘額同步功能

### 根本原因

雖然 PR #1100 成功實現了：
- ✅ `trader/bybit_trader.go` - 完整的 Bybit 交易器邏輯
- ✅ `manager/trader_manager.go` - API 密鑰配置
- ✅ `trader/auto_trader.go` - AutoTrader 中的 Bybit case
- ✅ `logger/decision_logger.go` - 0.055% 手續費率

但**遺漏了 `api/server.go` 中的 API 伺服器層集成**，這導致用戶實際上無法使用 Bybit。

### 解決方案

在 `api/server.go` 的兩個關鍵 switch 語句中添加 Bybit case：

1. **`handleCreateTrader()`** (約第 565 行) - 創建新交易員時的餘額查詢
2. **`handleSyncBalance()`** (約第 946 行) - 手動餘額同步功能

兩個位置現在都正確創建了 Bybit 交易器實例用於餘額查詢。

### 測試驗證

✅ 已在個人 fork (the-dev-z/nofx, z-dev-v3 分支) 上測試：
- ✅ 成功創建 Bybit 交易機器人
- ✅ 正確查詢 Bybit 帳戶餘額
- ✅ 餘額同步功能正常工作

### 影響範圍

此修復完成了 PR #1100 的 Bybit 集成，使用戶能夠：
- 🤖 創建 Bybit 交易機器人
- 💰 查詢即時 Bybit 餘額
- 🔄 從 Bybit 帳戶同步初始餘額

---

**Related:** #1100 (original Bybit PR)  
**Fixes:** Incomplete Bybit integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
