### PR TITLE
docs: fix Docker deployment doc links in i18n READMEs

### DIFF
--- a/docs/i18n/ja/README.md
+++ b/docs/i18n/ja/README.md
@@ -301,7 +301,7 @@ docker compose up -d --build
 ```
 
 **📖 詳細なDockerデプロイガイド、トラブルシューティング、高度な設定について：**
-- **English**: See [docker-deploy.md](../../getting-started/docker-deploy.en.md)
+- **English**: See [docker-deploy.en.md](../../getting-started/docker-deploy.en.md)
 - **中文**: 查看 [docker-deploy.zh-CN.md](../../getting-started/docker-deploy.zh-CN.md)
 - **日本語**: [docker-deploy.md](docker-deploy.md)を参照
 

--- a/docs/i18n/ko/README.md
+++ b/docs/i18n/ko/README.md
@@ -267,8 +267,8 @@ docker compose up -d --build
 
 **📖 자세한 Docker 배포 가이드, 문제 해결 및 고급 구성:**
 - **한국어**: Docker 문서 참조 (곧 제공 예정)
-- **English**: See [DOCKER_DEPLOY.en.md](../../getting-started/docker-deploy.en.md)
-- **中文**: 查看 [DOCKER_DEPLOY.md](../../getting-started/docker-deploy.zh-CN.md)
+- **English**: See [docker-deploy.en.md](../../getting-started/docker-deploy.en.md)
+- **中文**: 查看 [docker-deploy.zh-CN.md](../../getting-started/docker-deploy.zh-CN.md)
 
 ---
 

--- a/docs/i18n/ru/README.md
+++ b/docs/i18n/ru/README.md
@@ -390,9 +390,9 @@ docker compose up -d --build
 
 **📖 Подробное руководство по развертыванию Docker, устранению неполадок и расширенной конфигурации:**
 - **Русский**: См. документацию Docker (скоро будет доступно)
-- **English**: See [DOCKER_DEPLOY.en.md](DOCKER_DEPLOY.en.md)
-- **中文**: 查看 [DOCKER_DEPLOY.md](DOCKER_DEPLOY.md)
-- **日本語**: [DOCKER_DEPLOY.ja.md](DOCKER_DEPLOY.ja.md)を参照
+- **English**: See [docker-deploy.en.md](../../getting-started/docker-deploy.en.md)
+- **中文**: 查看 [docker-deploy.zh-CN.md](../../getting-started/docker-deploy.zh-CN.md)
+- **日本語**: [docker-deploy.md](../ja/docker-deploy.md)を参照
 
 ---
 

--- a/docs/i18n/uk/README.md
+++ b/docs/i18n/uk/README.md
@@ -393,9 +393,9 @@ docker compose up -d --build
 
 **📖 Детальний посібник з розгортання Docker, усунення несправностей та розширеної конфігурації:**
 - **Українська**: Дивіться документацію Docker (скоро буде доступно)
-- **English**: See [DOCKER_DEPLOY.en.md](DOCKER_DEPLOY.en.md)
-- **中文**: 查看 [DOCKER_DEPLOY.md](DOCKER_DEPLOY.md)
-- **日本語**: [DOCKER_DEPLOY.ja.md](DOCKER_DEPLOY.ja.md)を参照
+- **English**: See [docker-deploy.en.md](../../getting-started/docker-deploy.en.md)
+- **中文**: 查看 [docker-deploy.zh-CN.md](../../getting-started/docker-deploy.zh-CN.md)
+- **日本語**: [docker-deploy.md](../ja/docker-deploy.md)を参照
 
 ---
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -271,9 +271,9 @@ docker compose up -d --build
 ```
 
 **📖 详细的Docker部署教程、故障排查和高级配置：**
-- **中文**: 查看 [DOCKER_DEPLOY.md](DOCKER_DEPLOY.md)
-- **English**: See [DOCKER_DEPLOY.en.md](DOCKER_DEPLOY.en.md)
-- **日本語**: [DOCKER_DEPLOY.ja.md](DOCKER_DEPLOY.ja.md)を参照
+- **中文**: 查看 [docker-deploy.zh-CN.md](../../getting-started/docker-deploy.zh-CN.md)
+- **English**: See [docker-deploy.en.md](../../getting-started/docker-deploy.en.md)
+- **日本語**: [docker-deploy.md](../ja/docker-deploy.md)を参照
 
 ---
 


### PR DESCRIPTION
## 📝 Description

**English:** 

Fixed broken Docker deployment documentation links in 5 i18n README files (ru, zh-CN, uk, ja, ko), corrected file names from DOCKER_DEPLOY to docker-deploy and added proper relative paths to getting-started directory



---

## 🎯 Type of Change | 变更类型

- [ ] 🐛 Bug fix | 修复 Bug
- [ ] ✨ New feature | 新功能
- [ ] 💥 Breaking change | 破坏性变更
- [x] 📝 Documentation update | 文档更新
- [ ] 🎨 Code style update | 代码样式更新
- [ ] ♻️ Refactoring | 重构
- [ ] ⚡ Performance improvement | 性能优化
- [ ] ✅ Test update | 测试更新
- [ ] 🔧 Build/config change | 构建/配置变更
- [ ] 🔒 Security fix | 安全修复
