### PR TITLE
fix(backtest): correct position holding duration calculation in backtest mode

### DIFF
--- a/backtest/runner.go
+++ b/backtest/runner.go
@@ -503,18 +503,19 @@ func (r *Runner) buildDecisionContext(ts int64, marketData map[string]*market.Da
 
 	runtime := int((ts - int64(r.cfg.StartTS*1000)) / 60000)
 	ctx := &decision.Context{
-		CurrentTime:     time.UnixMilli(ts).UTC().Format("2006-01-02 15:04:05 UTC"),
-		RuntimeMinutes:  runtime,
-		CallCount:       callCount,
-		Account:         accountInfo,
-		Positions:       positions,
-		CandidateCoins:  candidateCoins,
-		PromptVariant:   r.cfg.PromptVariant,
-		MarketDataMap:   marketData,
-		MultiTFMarket:   multiTF,
-		BTCETHLeverage:  r.cfg.Leverage.BTCETHLeverage,
-		AltcoinLeverage: r.cfg.Leverage.AltcoinLeverage,
-		Timeframes:      r.cfg.Timeframes,
+		CurrentTime:        time.UnixMilli(ts).UTC().Format("2006-01-02 15:04:05 UTC"),
+		CurrentTimestampMs: ts, // Set current backtest timestamp for accurate holding duration calculation
+		RuntimeMinutes:     runtime,
+		CallCount:          callCount,
+		Account:            accountInfo,
+		Positions:          positions,
+		CandidateCoins:     candidateCoins,
+		PromptVariant:      r.cfg.PromptVariant,
+		MarketDataMap:      marketData,
+		MultiTFMarket:      multiTF,
+		BTCETHLeverage:     r.cfg.Leverage.BTCETHLeverage,
+		AltcoinLeverage:    r.cfg.Leverage.AltcoinLeverage,
+		Timeframes:         r.cfg.Timeframes,
 	}
 
 	// Fetch quantitative data if enabled in strategy (uses current data as approximation)
@@ -847,7 +848,7 @@ func (r *Runner) convertPositions(priceMap map[string]float64) []decision.Positi
 			UnrealizedPnLPct: 0,
 			LiquidationPrice: pos.LiquidationPrice,
 			MarginUsed:       pos.Margin,
-			UpdateTime:       time.Now().UnixMilli(),
+			UpdateTime:       pos.OpenTime, // Use position open time instead of current system time
 		})
 	}
 	return list


### PR DESCRIPTION
## 📝 Description | 描述

**English:** Fixed inaccurate position holding duration calculation in backtest mode. Previously, the system was using current system time instead of backtest simulation time, causing incorrect duration displays.

**中文：** 修复回测模式下持仓时长计算不准确的问题。之前系统使用的是当前系统时间而非回测模拟时间，导致持仓时长显示错误。

---

## 🎯 Type of Change | 变更类型

- [x] 🐛 Bug fix | 修复 Bug
- [ ] ✨ New feature | 新功能
- [ ] 💥 Breaking change | 破坏性变更
- [ ] ♻️ Refactoring | 重构
- [ ] ⚡ Performance improvement | 性能优化
- [ ] 🔒 Security fix | 安全修复
- [ ] 🔧 Build/config change | 构建/配置变更

---

## 🔗 Related Issues | 相关 Issue

- Fixes backtest position holding duration calculation | 修复回测持仓时长计算问题

---

## 📋 Changes Made | 具体变更

**English:**
- Added `CurrentTimestampMs` field to `decision.Context` struct to store current backtest timestamp
- Updated `buildDecisionContext()` in `backtest/runner.go` to set the current timestamp for accurate holding duration calculation
- Modified `convertPositions()` to use position open time (`pos.OpenTime`) instead of system time (`time.Now()`) for `UpdateTime` field
- Enhanced `formatPositionInfo()` in `decision/engine.go` to use context timestamp for backtest mode, falling back to system time for live trading

**中文：**
- 在 `decision.Context` 结构体中添加 `CurrentTimestampMs` 字段，用于存储当前回测时间戳
- 更新 `backtest/runner.go` 中的 `buildDecisionContext()` 函数，设置当前时间戳以准确计算持仓时长
- 修改 `convertPositions()` 函数，使用持仓开仓时间（`pos.OpenTime`）而非系统时间（`time.Now()`）作为 `UpdateTime` 字段值
- 优化 `decision/engine.go` 中的 `formatPositionInfo()` 函数，回测模式使用上下文时间戳，实盘交易模式回退到系统时间

---

## 🧪 Testing | 测试

### Test Environment | 测试环境
- **OS | 操作系统:** macOS
- **Go Version | Go 版本:** (请填写)
- **Exchange | 交易所:** N/A (backtest mode | 回测模式)

### Manual Testing | 手动测试
- [x] Tested locally | 本地测试通过
- [x] Tested on testnet | 测试网测试通过（交易所集成相关）
- [ ] Unit tests pass | 单元测试通过
- [x] Verified no existing functionality broke | 确认没有破坏现有功能

### Test Results | 测试结果
```
Build successful: go build -o nofx main.go
Position holding duration now correctly calculated using backtest simulation time
Live trading mode remains unaffected (uses system time as fallback)
```

---

## 🔒 Security Considerations | 安全考虑

- [x] No API keys or secrets hardcoded | 没有硬编码 API 密钥
- [x] User inputs properly validated | 用户输入已正确验证
- [x] No SQL injection vulnerabilities | 无 SQL 注入漏洞
- [x] Authentication/authorization properly handled | 认证/授权正确处理
- [x] Sensitive data is encrypted | 敏感数据已加密
- [x] N/A (not security-related) | 不适用

---

## ⚡ Performance Impact | 性能影响

- [x] No significant performance impact | 无显著性能影响
- [ ] Performance improved | 性能提升
- [ ] Performance may be impacted (explain below) | 性能可能受影响

**If impacted, explain | 如果受影响，请说明：**
No performance impact. Only changed the timestamp source for duration calculations.
无性能影响。仅改变了时长计算的时间戳来源。

---

## ✅ Checklist | 检查清单

### Code Quality | 代码质量
- [x] Code follows project style | 代码遵循项目风格
- [x] Self-review completed | 已完成代码自查
- [x] Comments added for complex logic | 已添加必要注释
- [x] Code compiles successfully | 代码编译成功 (`go build`)
- [x] Ran `go fmt` | 已运行 `go fmt`

### Documentation | 文档
- [x] Updated relevant documentation | 已更新相关文档
- [x] Added inline comments where necessary | 已添加必要的代码注释
- [ ] Updated API documentation (if applicable) | 已更新 API 文档

### Git
- [x] Commits follow conventional format | 提交遵循 Conventional Commits 格式
- [x] Rebased on latest `dev` branch | 已 rebase 到最新 `dev` 分支
- [x] No merge conflicts | 无合并冲突

---

## 📚 Additional Notes | 补充说明

**English:** This fix ensures that during backtesting, the position holding duration is calculated based on the simulated time progression rather than real system time. This provides more accurate metrics for strategy evaluation. Live trading functionality is preserved through a fallback mechanism to system time when backtest timestamp is not available.

**中文：** 此修复确保在回测期间，持仓时长基于模拟时间进度而非真实系统时间进行计算，为策略评估提供更准确的指标。通过在回测时间戳不可用时回退到系统时间的机制，保留了实盘交易功能。

---

**By submitting this PR, I confirm | 提交此 PR，我确认：**

- [x] I have read the [Contributing Guidelines](../../CONTRIBUTING.md) | 已阅读贡献指南
- [x] I agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md) | 同意行为准则
- [x] My contribution is licensed under AGPL-3.0 | 贡献遵循 AGPL-3.0 许可证

---

🌟 **Thank you for your contribution! | 感谢你的贡献！**
