### PR TITLE
feat(okx/hyperliquid): add Testnet/Simulated trading support

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -605,6 +605,7 @@ func (s *Server) handleCreateTrader(c *gin.Context) {
 				string(exchangeCfg.APIKey),
 				string(exchangeCfg.SecretKey),
 				string(exchangeCfg.Passphrase),
+				exchangeCfg.Testnet,
 			)
 		case "bitget":
 			tempTrader = trader.NewBitgetTrader(
@@ -1149,6 +1150,7 @@ func (s *Server) handleSyncBalance(c *gin.Context) {
 			string(exchangeCfg.APIKey),
 			string(exchangeCfg.SecretKey),
 			string(exchangeCfg.Passphrase),
+			exchangeCfg.Testnet,
 		)
 	case "bitget":
 		tempTrader = trader.NewBitgetTrader(
@@ -1301,6 +1303,7 @@ func (s *Server) handleClosePosition(c *gin.Context) {
 			string(exchangeCfg.APIKey),
 			string(exchangeCfg.SecretKey),
 			string(exchangeCfg.Passphrase),
+			exchangeCfg.Testnet,
 		)
 	case "bitget":
 		tempTrader = trader.NewBitgetTrader(

--- a/docs/getting-started/okx-api.md
+++ b/docs/getting-started/okx-api.md
@@ -56,6 +56,7 @@ Add your API credentials through the NOFX web interface:
    - **Secret Key**
    - **Passphrase**
 5. Save configuration
+6. If you are using an OKX demo/paper account, enable **Use Simulated Trading** so NOFX adds `x-simulated-trading: 1` to every request.
 
 ## Troubleshooting
 

--- a/manager/trader_manager.go
+++ b/manager/trader_manager.go
@@ -407,7 +407,6 @@ func (tm *TraderManager) GetTopTradersData() (map[string]interface{}, error) {
 	return result, nil
 }
 
-
 // RemoveTrader removes a trader from memory (does not affect database)
 // Used to force reload when updating trader configuration
 // If the trader is running, it will be stopped first
@@ -658,17 +657,17 @@ func (tm *TraderManager) addTraderFromStore(traderCfg *store.Trader, aiModelCfg 
 		BinanceAPIKey:         "",
 		BinanceSecretKey:      "",
 		HyperliquidPrivateKey: "",
-		HyperliquidTestnet:    exchangeCfg.Testnet,
 		UseQwen:               aiModelCfg.Provider == "qwen",
 		DeepSeekKey:           "",
 		QwenKey:               "",
 		CustomAPIURL:          aiModelCfg.CustomAPIURL,
 		CustomModelName:       aiModelCfg.CustomModelName,
-		ScanInterval:         time.Duration(traderCfg.ScanIntervalMinutes) * time.Minute,
-		InitialBalance:       traderCfg.InitialBalance,
-		IsCrossMargin:        traderCfg.IsCrossMargin,
-		ShowInCompetition:    traderCfg.ShowInCompetition,
-		StrategyConfig:       strategyConfig,
+		ScanInterval:          time.Duration(traderCfg.ScanIntervalMinutes) * time.Minute,
+		InitialBalance:        traderCfg.InitialBalance,
+		IsCrossMargin:         traderCfg.IsCrossMargin,
+		ShowInCompetition:     traderCfg.ShowInCompetition,
+		Testnet:               exchangeCfg.Testnet,
+		StrategyConfig:        strategyConfig,
 	}
 
 	logger.Infof("📊 Loading trader %s: ScanIntervalMinutes=%d (from DB), ScanInterval=%v",
@@ -702,7 +701,6 @@ func (tm *TraderManager) addTraderFromStore(traderCfg *store.Trader, aiModelCfg 
 		traderConfig.LighterWalletAddr = exchangeCfg.LighterWalletAddr
 		traderConfig.LighterAPIKeyPrivateKey = string(exchangeCfg.LighterAPIKeyPrivateKey)
 		traderConfig.LighterAPIKeyIndex = exchangeCfg.LighterAPIKeyIndex
-		traderConfig.LighterTestnet = exchangeCfg.Testnet
 	}
 
 	// Set API keys based on AI model (convert EncryptedString to string)

--- a/trader/auto_trader.go
+++ b/trader/auto_trader.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"nofx/kernel"
 	"nofx/experience"
+	"nofx/kernel"
 	"nofx/logger"
 	"nofx/market"
 	"nofx/mcp"
@@ -35,19 +35,18 @@ type AutoTraderConfig struct {
 	BybitSecretKey string
 
 	// OKX API configuration
-	OKXAPIKey    string
-	OKXSecretKey string
+	OKXAPIKey     string
+	OKXSecretKey  string
 	OKXPassphrase string
 
 	// Bitget API configuration
-	BitgetAPIKey    string
-	BitgetSecretKey string
+	BitgetAPIKey     string
+	BitgetSecretKey  string
 	BitgetPassphrase string
 
 	// Hyperliquid configuration
 	HyperliquidPrivateKey string
 	HyperliquidWalletAddr string
-	HyperliquidTestnet    bool
 
 	// Aster configuration
 	AsterUser       string // Aster main wallet address
@@ -59,7 +58,6 @@ type AutoTraderConfig struct {
 	LighterPrivateKey       string // LIGHTER L1 private key (for account identification)
 	LighterAPIKeyPrivateKey string // LIGHTER API Key private key (40 bytes, for transaction signing)
 	LighterAPIKeyIndex      int    // LIGHTER API Key index (0-255)
-	LighterTestnet          bool   // Whether to use testnet
 
 	// AI configuration
 	UseQwen     bool
@@ -88,6 +86,9 @@ type AutoTraderConfig struct {
 	// Competition visibility
 	ShowInCompetition bool // Whether to show in competition page
 
+	// Testnet / simulated trading switch
+	Testnet bool // true = use exchange test environment when supported
+
 	// Strategy configuration (use complete strategy config)
 	StrategyConfig *store.StrategyConfig // Strategy configuration (includes coin sources, indicators, risk control, prompts, etc.)
 }
@@ -103,9 +104,9 @@ type AutoTrader struct {
 	config                AutoTraderConfig
 	trader                Trader // Use Trader interface (supports multiple platforms)
 	mcpClient             mcp.AIClient
-	store                 *store.Store             // Data storage (decision records, etc.)
+	store                 *store.Store           // Data storage (decision records, etc.)
 	strategyEngine        *kernel.StrategyEngine // Strategy engine (uses strategy configuration)
-	cycleNumber           int                      // Current cycle number
+	cycleNumber           int                    // Current cycle number
 	initialBalance        float64
 	dailyPnL              float64
 	customPrompt          string // Custom trading strategy prompt
@@ -229,13 +230,13 @@ func NewAutoTrader(config AutoTraderConfig, st *store.Store, userID string) (*Au
 		trader = NewBybitTrader(config.BybitAPIKey, config.BybitSecretKey)
 	case "okx":
 		logger.Infof("🏦 [%s] Using OKX Futures trading", config.Name)
-		trader = NewOKXTrader(config.OKXAPIKey, config.OKXSecretKey, config.OKXPassphrase)
+		trader = NewOKXTrader(config.OKXAPIKey, config.OKXSecretKey, config.OKXPassphrase, config.Testnet)
 	case "bitget":
 		logger.Infof("🏦 [%s] Using Bitget Futures trading", config.Name)
 		trader = NewBitgetTrader(config.BitgetAPIKey, config.BitgetSecretKey, config.BitgetPassphrase)
 	case "hyperliquid":
 		logger.Infof("🏦 [%s] Using Hyperliquid trading", config.Name)
-		trader, err = NewHyperliquidTrader(config.HyperliquidPrivateKey, config.HyperliquidWalletAddr, config.HyperliquidTestnet)
+		trader, err = NewHyperliquidTrader(config.HyperliquidPrivateKey, config.HyperliquidWalletAddr, config.Testnet)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize Hyperliquid trader: %w", err)
 		}
@@ -2079,22 +2080,22 @@ func (at *AutoTrader) recordOrderFill(orderRecordID int64, exchangeOrderID, symb
 	normalizedSymbol := market.Normalize(symbol)
 
 	fill := &store.TraderFill{
-		TraderID:         at.id,
-		ExchangeID:       at.exchangeID,
-		ExchangeType:     at.exchange,
-		OrderID:          orderRecordID,
-		ExchangeOrderID:  exchangeOrderID,
-		ExchangeTradeID:  tradeID,
-		Symbol:           normalizedSymbol,
-		Side:             side,
-		Price:            price,
-		Quantity:         quantity,
-		QuoteQuantity:    price * quantity,
-		Commission:       fee,
-		CommissionAsset:  "USDT",
-		RealizedPnL:      0, // Will be calculated for close orders
-		IsMaker:          false, // Market orders are usually taker
-		CreatedAt:        time.Now().UTC().UnixMilli(),
+		TraderID:        at.id,
+		ExchangeID:      at.exchangeID,
+		ExchangeType:    at.exchange,
+		OrderID:         orderRecordID,
+		ExchangeOrderID: exchangeOrderID,
+		ExchangeTradeID: tradeID,
+		Symbol:          normalizedSymbol,
+		Side:            side,
+		Price:           price,
+		Quantity:        quantity,
+		QuoteQuantity:   price * quantity,
+		Commission:      fee,
+		CommissionAsset: "USDT",
+		RealizedPnL:     0,     // Will be calculated for close orders
+		IsMaker:         false, // Market orders are usually taker
+		CreatedAt:       time.Now().UTC().UnixMilli(),
 	}
 
 	// Calculate realized PnL for close orders
@@ -2222,4 +2223,3 @@ func getSideFromAction(action string) string {
 func (at *AutoTrader) GetOpenOrders(symbol string) ([]OpenOrder, error) {
 	return at.trader.GetOpenOrders(symbol)
 }
-

--- a/trader/okx_trader.go
+++ b/trader/okx_trader.go
@@ -38,9 +38,10 @@ const (
 
 // OKXTrader OKX futures trader
 type OKXTrader struct {
-	apiKey     string
-	secretKey  string
-	passphrase string
+	apiKey       string
+	secretKey    string
+	passphrase   string
+	useSimulated bool
 
 	// Margin mode setting
 	isCrossMargin bool
@@ -104,7 +105,7 @@ func genOkxClOrdID() string {
 }
 
 // NewOKXTrader creates OKX trader
-func NewOKXTrader(apiKey, secretKey, passphrase string) *OKXTrader {
+func NewOKXTrader(apiKey, secretKey, passphrase string, useSimulated bool) *OKXTrader {
 	// Use default transport which respects system proxy settings
 	// OKX requires proxy in China due to DNS pollution
 	httpClient := &http.Client{
@@ -116,6 +117,7 @@ func NewOKXTrader(apiKey, secretKey, passphrase string) *OKXTrader {
 		apiKey:           apiKey,
 		secretKey:        secretKey,
 		passphrase:       passphrase,
+		useSimulated:     useSimulated,
 		httpClient:       httpClient,
 		cacheDuration:    15 * time.Second,
 		instrumentsCache: make(map[string]*OKXInstrument),
@@ -214,8 +216,12 @@ func (t *OKXTrader) doRequest(method, path string, body interface{}) ([]byte, er
 	req.Header.Set("OK-ACCESS-TIMESTAMP", timestamp)
 	req.Header.Set("OK-ACCESS-PASSPHRASE", t.passphrase)
 	req.Header.Set("Content-Type", "application/json")
-	// Set request header
-	req.Header.Set("x-simulated-trading", "0")
+	// Set simulated trading header (1 for simulated accounts, 0 for live)
+	simulatedFlag := "0"
+	if t.useSimulated {
+		simulatedFlag = "1"
+	}
+	req.Header.Set("x-simulated-trading", simulatedFlag)
 
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
@@ -1304,19 +1310,19 @@ func (t *OKXTrader) GetClosedPnL(startTime time.Time, limit int) ([]ClosedPnLRec
 		Code string `json:"code"`
 		Msg  string `json:"msg"`
 		Data []struct {
-			InstID      string `json:"instId"`      // Instrument ID (e.g., "BTC-USDT-SWAP")
-			Direction   string `json:"direction"`   // Position direction: "long" or "short"
-			OpenAvgPx   string `json:"openAvgPx"`   // Average open price
-			CloseAvgPx  string `json:"closeAvgPx"`  // Average close price
+			InstID        string `json:"instId"`        // Instrument ID (e.g., "BTC-USDT-SWAP")
+			Direction     string `json:"direction"`     // Position direction: "long" or "short"
+			OpenAvgPx     string `json:"openAvgPx"`     // Average open price
+			CloseAvgPx    string `json:"closeAvgPx"`    // Average close price
 			CloseTotalPos string `json:"closeTotalPos"` // Closed position quantity
-			RealizedPnl string `json:"realizedPnl"` // Realized PnL
-			Fee         string `json:"fee"`         // Total fee
-			FundingFee  string `json:"fundingFee"`  // Funding fee
-			Lever       string `json:"lever"`       // Leverage
-			CTime       string `json:"cTime"`       // Position open time
-			UTime       string `json:"uTime"`       // Position close time
-			Type        string `json:"type"`        // Close type: 1=close position, 2=partial close, 3=liquidation, 4=partial liquidation
-			PosId       string `json:"posId"`       // Position ID
+			RealizedPnl   string `json:"realizedPnl"`   // Realized PnL
+			Fee           string `json:"fee"`           // Total fee
+			FundingFee    string `json:"fundingFee"`    // Funding fee
+			Lever         string `json:"lever"`         // Leverage
+			CTime         string `json:"cTime"`         // Position open time
+			UTime         string `json:"uTime"`         // Position close time
+			Type          string `json:"type"`          // Close type: 1=close position, 2=partial close, 3=liquidation, 4=partial liquidation
+			PosId         string `json:"posId"`         // Position ID
 		} `json:"data"`
 	}
 

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -316,8 +316,13 @@ export const translations = {
     aiScanInterval: 'AI Scan Decision Interval (minutes)',
     scanIntervalRecommend: 'Recommended: 3-10 minutes',
     useTestnet: 'Use Testnet',
+    useSimulatedTrading: 'Use Simulated Trading',
     enabled: 'Enabled',
     save: 'Save',
+    okxSimulatedDescription:
+      'Add OKX header x-simulated-trading: 1 for all requests (paper trading sandbox)',
+    hyperliquidTestnetDescription:
+      'Connect to Hyperliquid testnet endpoint for development trading',
 
     // AI Model Configuration
     officialAPI: 'Official API',
@@ -1520,8 +1525,13 @@ export const translations = {
     aiScanInterval: 'AI 扫描决策间隔 (分钟)',
     scanIntervalRecommend: '建议: 3-10分钟',
     useTestnet: '使用测试网',
+    useSimulatedTrading: '使用模拟盘',
     enabled: '启用',
     save: '保存',
+    okxSimulatedDescription:
+      '为所有 OKX 请求自动添加 x-simulated-trading: 1 头部，适用于模拟盘账号',
+    hyperliquidTestnetDescription:
+      '连接 Hyperliquid 官方测试网，便于无风险验证策略',
 
     // AI Model Configuration
     officialAPI: '官方API',


### PR DESCRIPTION
## 📝 Description | 描述

**English:** Add Testnet/Simulated trading support for OKX and Hyperliquid exchanges to enable safe strategy testing without real funds.

**中文：** 为 OKX 和 Hyperliquid 交易所添加测试网/模拟盘支持，允许在无需真实资金的情况下安全测试策略。

---

## 🎯 Type of Change | 变更类型

- [x] ✨ New feature | 新功能

---

## 🔗 Related Issues | 相关 Issue

- Related to testnet environment setup

---

## 📋 Changes Made | 具体变更

**English:**
- Added `Testnet` configuration property to `AutoTraderConfig`
- Updated OKX trader to support simulated trading header (`x-simulated-trading: 1`)
- Updated Hyperliquid trader to support testnet endpoint
- Added Testnet/Simulated trading toggle in UI for OKX and Hyperliquid
- Added i18n translations for testnet-related labels
- Updated API handlers to pass Testnet configuration when creating traders
- Refactored duplicate testnet fields into unified `Testnet` property

**中文：**
- 为 `AutoTraderConfig` 添加 `Testnet` 配置属性
- 更新 OKX trader 支持模拟盘头部 (`x-simulated-trading: 1`)
- 更新 Hyperliquid trader 支持测试网端点
- 在 UI 中为 OKX 和 Hyperliquid 添加测试网/模拟盘开关
- 添加测试网相关的 i18n 翻译
- 更新 API 处理程序在创建交易者时传递 Testnet 配置
- 重构重复的 testnet 字段为统一的 `Testnet` 属性

---

## 🧪 Testing | 测试

- [x] Tested locally | 本地测试通过
- [ ] Tests pass | 测试通过
- [x] Verified no existing functionality broke | 确认没有破坏现有功能

---

## ✅ Checklist | 检查清单

### Code Quality | 代码质量
- [x] Code follows project style | 代码遵循项目风格
- [x] Self-review completed | 已完成代码自查
- [x] Comments added for complex logic | 已添加必要注释

### Documentation | 文档
- [x] Updated relevant documentation | 已更新相关文档 (okx-api.md)

### Git
- [x] Commits follow conventional format | 提交遵循 Conventional Commits 格式
- [x] Rebased on latest `dev` branch | 已 rebase 到最新 `dev` 分支
- [x] No merge conflicts | 无合并冲突

---

## 📚 Additional Notes | 补充说明

**English:** 
- OKX uses the `x-simulated-trading: 1` header for demo/paper trading accounts
- Hyperliquid connects to the official testnet endpoint when Testnet is enabled
- The UI shows different labels and descriptions based on the exchange type (OKX: "Use Simulated Trading", Hyperliquid: "Use Testnet")

**中文：**
- OKX 使用 `x-simulated-trading: 1` 头部来支持模拟/演示交易账号
- Hyperliquid 在启用 Testnet 时连接到官方测试网端点
- UI 根据交易所类型显示不同的标签和描述（OKX: "使用模拟盘", Hyperliquid: "使用测试网"）