### PR TITLE
feat(bitget): support preset TP/SL in single API call

### DIFF
--- a/trader/auto_trader.go
+++ b/trader/auto_trader.go
@@ -1136,10 +1136,35 @@ func (at *AutoTrader) executeOpenLongWithRecord(decision *kernel.Decision, actio
 		// Continue execution, doesn't affect trading
 	}
 
-	// Open position
-	order, err := at.trader.OpenLong(decision.Symbol, quantity, decision.Leverage)
-	if err != nil {
-		return err
+	// Open position - try to use OpenLongWithTPSL if available (single API call with TP/SL)
+	var order map[string]interface{}
+	if trader, ok := at.trader.(interface {
+		OpenLongWithTPSL(symbol string, quantity float64, leverage int, stopLoss, takeProfit float64) (map[string]interface{}, error)
+	}); ok && (decision.StopLoss > 0 || decision.TakeProfit > 0) {
+		// Use optimized method that includes TP/SL in single API call (e.g., Bitget)
+		order, err = trader.OpenLongWithTPSL(decision.Symbol, quantity, decision.Leverage, decision.StopLoss, decision.TakeProfit)
+		if err != nil {
+			return err
+		}
+		logger.Infof("  ✓ Position opened with preset TP/SL (single API call)")
+	} else {
+		// Fallback to legacy method (separate API calls)
+		order, err = at.trader.OpenLong(decision.Symbol, quantity, decision.Leverage)
+		if err != nil {
+			return err
+		}
+
+		// Set stop loss and take profit separately
+		if decision.StopLoss > 0 {
+			if err := at.trader.SetStopLoss(decision.Symbol, "LONG", quantity, decision.StopLoss); err != nil {
+				logger.Infof("  ⚠ Failed to set stop loss: %v", err)
+			}
+		}
+		if decision.TakeProfit > 0 {
+			if err := at.trader.SetTakeProfit(decision.Symbol, "LONG", quantity, decision.TakeProfit); err != nil {
+				logger.Infof("  ⚠ Failed to set take profit: %v", err)
+			}
+		}
 	}
 
 	// Record order ID
@@ -1155,14 +1180,6 @@ func (at *AutoTrader) executeOpenLongWithRecord(decision *kernel.Decision, actio
 	// Record position opening time
 	posKey := decision.Symbol + "_long"
 	at.positionFirstSeenTime[posKey] = time.Now().UnixMilli()
-
-	// Set stop loss and take profit
-	if err := at.trader.SetStopLoss(decision.Symbol, "LONG", quantity, decision.StopLoss); err != nil {
-		logger.Infof("  ⚠ Failed to set stop loss: %v", err)
-	}
-	if err := at.trader.SetTakeProfit(decision.Symbol, "LONG", quantity, decision.TakeProfit); err != nil {
-		logger.Infof("  ⚠ Failed to set take profit: %v", err)
-	}
 
 	return nil
 }
@@ -1253,10 +1270,35 @@ func (at *AutoTrader) executeOpenShortWithRecord(decision *kernel.Decision, acti
 		// Continue execution, doesn't affect trading
 	}
 
-	// Open position
-	order, err := at.trader.OpenShort(decision.Symbol, quantity, decision.Leverage)
-	if err != nil {
-		return err
+	// Open position - try to use OpenShortWithTPSL if available (single API call with TP/SL)
+	var order map[string]interface{}
+	if trader, ok := at.trader.(interface {
+		OpenShortWithTPSL(symbol string, quantity float64, leverage int, stopLoss, takeProfit float64) (map[string]interface{}, error)
+	}); ok && (decision.StopLoss > 0 || decision.TakeProfit > 0) {
+		// Use optimized method that includes TP/SL in single API call (e.g., Bitget)
+		order, err = trader.OpenShortWithTPSL(decision.Symbol, quantity, decision.Leverage, decision.StopLoss, decision.TakeProfit)
+		if err != nil {
+			return err
+		}
+		logger.Infof("  ✓ Position opened with preset TP/SL (single API call)")
+	} else {
+		// Fallback to legacy method (separate API calls)
+		order, err = at.trader.OpenShort(decision.Symbol, quantity, decision.Leverage)
+		if err != nil {
+			return err
+		}
+
+		// Set stop loss and take profit separately
+		if decision.StopLoss > 0 {
+			if err := at.trader.SetStopLoss(decision.Symbol, "SHORT", quantity, decision.StopLoss); err != nil {
+				logger.Infof("  ⚠ Failed to set stop loss: %v", err)
+			}
+		}
+		if decision.TakeProfit > 0 {
+			if err := at.trader.SetTakeProfit(decision.Symbol, "SHORT", quantity, decision.TakeProfit); err != nil {
+				logger.Infof("  ⚠ Failed to set take profit: %v", err)
+			}
+		}
 	}
 
 	// Record order ID
@@ -1272,14 +1314,6 @@ func (at *AutoTrader) executeOpenShortWithRecord(decision *kernel.Decision, acti
 	// Record position opening time
 	posKey := decision.Symbol + "_short"
 	at.positionFirstSeenTime[posKey] = time.Now().UnixMilli()
-
-	// Set stop loss and take profit
-	if err := at.trader.SetStopLoss(decision.Symbol, "SHORT", quantity, decision.StopLoss); err != nil {
-		logger.Infof("  ⚠ Failed to set stop loss: %v", err)
-	}
-	if err := at.trader.SetTakeProfit(decision.Symbol, "SHORT", quantity, decision.TakeProfit); err != nil {
-		logger.Infof("  ⚠ Failed to set take profit: %v", err)
-	}
 
 	return nil
 }

--- a/trader/bitget/trader_test.go
+++ b/trader/bitget/trader_test.go
@@ -1,0 +1,119 @@
+package bitget
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// 测试 Bitget 下单（带止盈止损）
+// 运行: go test -v -run TestOpenLongWithTPSL ./trader/bitget/
+func TestOpenLongWithTPSL(t *testing.T) {
+	apiKey := os.Getenv("BITGET_API_KEY")
+	secretKey := os.Getenv("BITGET_SECRET_KEY")
+	passphrase := os.Getenv("BITGET_PASSPHRASE")
+
+	if apiKey == "" || secretKey == "" || passphrase == "" {
+		t.Skip("跳过测试: 需要设置环境变量 BITGET_API_KEY, BITGET_SECRET_KEY, BITGET_PASSPHRASE")
+	}
+
+	trader := NewBitgetTrader(apiKey, secretKey, passphrase)
+
+	// 测试参数 - 使用最小仓位
+	symbol := "BTCUSDT"
+	quantity := 0.001  // 最小数量
+	leverage := 5
+	stopLoss := 70000.0   // 止损价格（根据当前价格调整）
+	takeProfit := 110000.0 // 止盈价格
+
+	fmt.Printf("📊 测试 Bitget OpenLongWithTPSL\n")
+	fmt.Printf("   Symbol: %s\n", symbol)
+	fmt.Printf("   Quantity: %.4f\n", quantity)
+	fmt.Printf("   Leverage: %dx\n", leverage)
+	fmt.Printf("   StopLoss: %.2f\n", stopLoss)
+	fmt.Printf("   TakeProfit: %.2f\n", takeProfit)
+
+	// 先获取当前价格
+	price, err := trader.GetMarketPrice(symbol)
+	if err != nil {
+		t.Fatalf("获取价格失败: %v", err)
+	}
+	fmt.Printf("   当前价格: %.2f\n", price)
+
+	// 调整止盈止损
+	stopLoss = price * 0.95    // 5% 止损
+	takeProfit = price * 1.05  // 5% 止盈
+	fmt.Printf("   调整后 StopLoss: %.2f (%.1f%%)\n", stopLoss, (1-stopLoss/price)*100)
+	fmt.Printf("   调整后 TakeProfit: %.2f (+%.1f%%)\n", takeProfit, (takeProfit/price-1)*100)
+
+	// 执行下单
+	fmt.Println("\n🚀 开始下单...")
+	result, err := trader.OpenLongWithTPSL(symbol, quantity, leverage, stopLoss, takeProfit)
+	if err != nil {
+		t.Fatalf("下单失败: %v", err)
+	}
+
+	fmt.Printf("✅ 下单成功!\n")
+	fmt.Printf("   OrderId: %v\n", result["orderId"])
+	fmt.Printf("   Symbol: %v\n", result["symbol"])
+	fmt.Printf("   Status: %v\n", result["status"])
+
+	// 查看持仓确认
+	fmt.Println("\n📋 查看持仓...")
+	positions, err := trader.GetPositions()
+	if err != nil {
+		t.Logf("⚠️ 获取持仓失败: %v", err)
+	} else {
+		for _, pos := range positions {
+			if pos["symbol"] == symbol || pos["symbol"] == "BTCUSDT" {
+				fmt.Printf("   持仓: %v\n", pos)
+			}
+		}
+	}
+}
+
+// 测试获取账户余额
+func TestGetBalance(t *testing.T) {
+	apiKey := os.Getenv("BITGET_API_KEY")
+	secretKey := os.Getenv("BITGET_SECRET_KEY")
+	passphrase := os.Getenv("BITGET_PASSPHRASE")
+
+	if apiKey == "" || secretKey == "" || passphrase == "" {
+		t.Skip("跳过测试: 需要设置环境变量")
+	}
+
+	trader := NewBitgetTrader(apiKey, secretKey, passphrase)
+
+	balance, err := trader.GetBalance()
+	if err != nil {
+		t.Fatalf("获取余额失败: %v", err)
+	}
+
+	fmt.Printf("💰 账户余额:\n")
+	for k, v := range balance {
+		fmt.Printf("   %s: %v\n", k, v)
+	}
+}
+
+// 测试获取持仓
+func TestGetPositions(t *testing.T) {
+	apiKey := os.Getenv("BITGET_API_KEY")
+	secretKey := os.Getenv("BITGET_SECRET_KEY")
+	passphrase := os.Getenv("BITGET_PASSPHRASE")
+
+	if apiKey == "" || secretKey == "" || passphrase == "" {
+		t.Skip("跳过测试: 需要设置环境变量")
+	}
+
+	trader := NewBitgetTrader(apiKey, secretKey, passphrase)
+
+	positions, err := trader.GetPositions()
+	if err != nil {
+		t.Fatalf("获取持仓失败: %v", err)
+	}
+
+	fmt.Printf("📋 当前持仓 (%d):\n", len(positions))
+	for i, pos := range positions {
+		fmt.Printf("   [%d] %v\n", i+1, pos)
+	}
+}


### PR DESCRIPTION
## 📝 Description

实现 Bitget 交易所的预设止损止盈功能，通过在下单 API 中使用 `presetStopLossPrice` 和 `presetStopSurplusPrice` 参数，将原来的 3 次 API 调用优化为单次调用，提高订单设置的可靠性和执行效率。

---

## 🎯 Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🎨 Code style update
- [ ] ♻️ Refactoring
- [x] ⚡ Performance improvement
- [x] ✅ Test update
- [ ] 🔧 Build/config change
- [ ] 🔒 Security fix

---

## 🔗 Related Issues

- Closes # (Bitget 止损止盈不生效问题)

---

## 📋 Changes Made

- **trader.go**: 新增 `OpenLongWithTPSL()` 和 `OpenShortWithTPSL()` 方法，支持在单次 API 调用中设置预设止损止盈
- **trader.go**: 新增 `FormatPrice()` 方法处理价格精度（Bitget 要求价格为合约精度的倍数，如 BTC 需要 0.1 的倍数）
- **trader.go**: 重构 `openLongInternal()` 和 `openShortInternal()` 内部方法，支持可选的 TP/SL 参数
- **auto_trader.go**: 在 `executeOpenLongWithRecord()` 和 `executeOpenShortWithRecord()` 中使用类型断言检测 trader 是否支持新的 TPSL 方法
- **auto_trader.go**: 支持新方法时使用单次调用，否则回退到原有的 3 次调用方式（兼容其他交易所）
- **trader/bitget/trader_test.go**: 新增测试文件，包含 `TestOpenLongWithTPSL`、`TestGetBalance`、`TestGetPositions` 测试用例

---

## 🧪 Testing

- [x] Tested locally
- [x] Tests pass
- [x] Verified no existing functionality broke

**测试详情:**
- 使用真实 Bitget API 测试 `OpenLongWithTPSL` 方法
- 验证订单成功创建并包含预设止损止盈
- 确认价格精度格式化正确（通过 `FormatPrice` 方法）

---

## ✅ Checklist

### Code Quality
- [x] Code follows project style
- [x] Self-review completed
- [x] Comments added for complex logic

### Documentation
- [x] Updated relevant documentation

### Git
- [x] Commits follow conventional format
- [x] Rebased on latest `dev` branch
- [x] No merge conflicts

---

## 📚 Additional Notes

### 技术实现细节

1. **单次 API 调用**：使用 Bitget API V2 的 `/api/v2/mix/order/place-order` 端点，在请求体中添加 `presetStopLossPrice` 和 `presetStopSurplusPrice` 参数

2. **价格精度处理**：Bitget 对价格精度有严格要求（错误码 45115），通过 `FormatPrice()` 方法根据合约的 `PricePlace` 字段格式化价格

3. **向后兼容**：通过 Go 的类型断言模式，只有 Bitget trader 使用新方法，其他交易所继续使用原有的 3 次调用方式

```go
// 类型断言检测
type TPSLOpener interface {
    OpenLongWithTPSL(symbol string, amount, stopLoss, takeProfit float64) (string, error)
}

if opener, ok := at.trader.(TPSLOpener); ok {
    // 使用优化的单次调用
    return opener.OpenLongWithTPSL(symbol, amount, stopLoss, takeProfit)
}
// 回退到原有方式
```

---

**By submitting this PR, I confirm:**

- [x] I have read the Contributing Guidelines
- [x] I agree to the Code of Conduct
- [x] My contribution is licensed under AGPL-3.0

---

🌟 **Thank you for your contribution!**