### PR TITLE
feat(hyperliquid): Add Unified Account support for Spot as Perp collateral

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -484,6 +484,7 @@ type UpdateExchangeConfigRequest struct {
 		Passphrase              string `json:"passphrase"` // OKX specific
 		Testnet                 bool   `json:"testnet"`
 		HyperliquidWalletAddr   string `json:"hyperliquid_wallet_addr"`
+		HyperliquidUnifiedAcct  bool   `json:"hyperliquid_unified_account"` // Unified Account mode
 		AsterUser               string `json:"aster_user"`
 		AsterSigner             string `json:"aster_signer"`
 		AsterPrivateKey         string `json:"aster_private_key"`
@@ -600,6 +601,7 @@ func (s *Server) handleCreateTrader(c *gin.Context) {
 				string(exchangeCfg.APIKey), // private key
 				exchangeCfg.HyperliquidWalletAddr,
 				exchangeCfg.Testnet,
+				exchangeCfg.HyperliquidUnifiedAcct,
 			)
 		case "aster":
 			tempTrader, createErr = aster.NewAsterTrader(
@@ -1169,6 +1171,7 @@ func (s *Server) handleSyncBalance(c *gin.Context) {
 			string(exchangeCfg.APIKey),
 			exchangeCfg.HyperliquidWalletAddr,
 			exchangeCfg.Testnet,
+			exchangeCfg.HyperliquidUnifiedAcct,
 		)
 	case "aster":
 		tempTrader, createErr = aster.NewAsterTrader(
@@ -1332,6 +1335,7 @@ func (s *Server) handleClosePosition(c *gin.Context) {
 			string(exchangeCfg.APIKey),
 			exchangeCfg.HyperliquidWalletAddr,
 			exchangeCfg.Testnet,
+			exchangeCfg.HyperliquidUnifiedAcct,
 		)
 	case "aster":
 		tempTrader, createErr = aster.NewAsterTrader(
@@ -1906,7 +1910,7 @@ func (s *Server) handleUpdateExchangeConfigs(c *gin.Context) {
 			tradersToReload[t.ID] = true
 		}
 
-		err := s.store.Exchange().Update(userID, exchangeID, exchangeData.Enabled, exchangeData.APIKey, exchangeData.SecretKey, exchangeData.Passphrase, exchangeData.Testnet, exchangeData.HyperliquidWalletAddr, exchangeData.AsterUser, exchangeData.AsterSigner, exchangeData.AsterPrivateKey, exchangeData.LighterWalletAddr, exchangeData.LighterPrivateKey, exchangeData.LighterAPIKeyPrivateKey, exchangeData.LighterAPIKeyIndex)
+		err := s.store.Exchange().Update(userID, exchangeID, exchangeData.Enabled, exchangeData.APIKey, exchangeData.SecretKey, exchangeData.Passphrase, exchangeData.Testnet, exchangeData.HyperliquidWalletAddr, exchangeData.HyperliquidUnifiedAcct, exchangeData.AsterUser, exchangeData.AsterSigner, exchangeData.AsterPrivateKey, exchangeData.LighterWalletAddr, exchangeData.LighterPrivateKey, exchangeData.LighterAPIKeyPrivateKey, exchangeData.LighterAPIKeyIndex)
 		if err != nil {
 			SafeInternalError(c, fmt.Sprintf("Update exchange %s", exchangeID), err)
 			return
@@ -1940,6 +1944,7 @@ type CreateExchangeRequest struct {
 	Passphrase              string `json:"passphrase"`
 	Testnet                 bool   `json:"testnet"`
 	HyperliquidWalletAddr   string `json:"hyperliquid_wallet_addr"`
+	HyperliquidUnifiedAcct  bool   `json:"hyperliquid_unified_account"` // Unified Account mode: Spot as Perp collateral
 	AsterUser               string `json:"aster_user"`
 	AsterSigner             string `json:"aster_signer"`
 	AsterPrivateKey         string `json:"aster_private_key"`
@@ -2014,7 +2019,8 @@ func (s *Server) handleCreateExchange(c *gin.Context) {
 	id, err := s.store.Exchange().Create(
 		userID, req.ExchangeType, req.AccountName, req.Enabled,
 		req.APIKey, req.SecretKey, req.Passphrase, req.Testnet,
-		req.HyperliquidWalletAddr, req.AsterUser, req.AsterSigner, req.AsterPrivateKey,
+		req.HyperliquidWalletAddr, req.HyperliquidUnifiedAcct,
+		req.AsterUser, req.AsterSigner, req.AsterPrivateKey,
 		req.LighterWalletAddr, req.LighterPrivateKey, req.LighterAPIKeyPrivateKey, req.LighterAPIKeyIndex,
 	)
 	if err != nil {

--- a/manager/trader_manager.go
+++ b/manager/trader_manager.go
@@ -700,6 +700,7 @@ func (tm *TraderManager) addTraderFromStore(traderCfg *store.Trader, aiModelCfg 
 	case "hyperliquid":
 		traderConfig.HyperliquidPrivateKey = string(exchangeCfg.APIKey)
 		traderConfig.HyperliquidWalletAddr = exchangeCfg.HyperliquidWalletAddr
+		traderConfig.HyperliquidUnifiedAcct = exchangeCfg.HyperliquidUnifiedAcct
 	case "aster":
 		traderConfig.AsterUser = exchangeCfg.AsterUser
 		traderConfig.AsterSigner = exchangeCfg.AsterSigner

--- a/trader/auto_trader.go
+++ b/trader/auto_trader.go
@@ -63,9 +63,10 @@ type AutoTraderConfig struct {
 	KuCoinPassphrase string
 
 	// Hyperliquid configuration
-	HyperliquidPrivateKey string
-	HyperliquidWalletAddr string
-	HyperliquidTestnet    bool
+	HyperliquidPrivateKey  string
+	HyperliquidWalletAddr  string
+	HyperliquidTestnet     bool
+	HyperliquidUnifiedAcct bool // Unified Account mode: Spot USDC as Perp collateral
 
 	// Aster configuration
 	AsterUser       string // Aster main wallet address
@@ -260,7 +261,7 @@ func NewAutoTrader(config AutoTraderConfig, st *store.Store, userID string) (*Au
 		trader = kucoin.NewKuCoinTrader(config.KuCoinAPIKey, config.KuCoinSecretKey, config.KuCoinPassphrase)
 	case "hyperliquid":
 		logger.Infof("🏦 [%s] Using Hyperliquid trading", config.Name)
-		trader, err = hyperliquid.NewHyperliquidTrader(config.HyperliquidPrivateKey, config.HyperliquidWalletAddr, config.HyperliquidTestnet)
+		trader, err = hyperliquid.NewHyperliquidTrader(config.HyperliquidPrivateKey, config.HyperliquidWalletAddr, config.HyperliquidTestnet, config.HyperliquidUnifiedAcct)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize Hyperliquid trader: %w", err)
 		}


### PR DESCRIPTION
## Summary
Add Unified Account support for Hyperliquid where Spot USDC acts as Perp collateral.

## Motivation
Hyperliquid is moving to Unified Account as the default mode. This PR adds support so users with funds in Spot can trade Perpetuals without manual transfers.

## Changes
- New config field: `hyperliquid_unified_account` (default: true)
- Spot USDC balance added to available trading balance when enabled
- Update `HyperliquidTrader` to support unified account mode
- Update API request/response structs for unified account toggle
- Update trader config propagation from exchange config

## Files Changed (5 files, +58/-28 lines)
- `store/exchange.go` - Add config field
- `trader/hyperliquid/trader.go` - Core unified account logic  
- `trader/auto_trader.go` - Pass config to trader
- `manager/trader_manager.go` - Propagate config
- `api/server.go` - API request/response structs

## Testing
✅ Tested with real Hyperliquid account - Spot balance shows as available for Perp trading
✅ Backward compatible - existing users unaffected