### PR TITLE
feat: update default MiniMax model to M2.7

### DIFF
--- a/api/handler_ai_model.go
+++ b/api/handler_ai_model.go
@@ -201,7 +201,7 @@ func (s *Server) handleGetSupportedModels(c *gin.Context) {
 		{"id": "gemini", "name": "Google Gemini", "provider": "gemini", "defaultModel": "gemini-3-pro-preview"},
 		{"id": "grok", "name": "Grok (xAI)", "provider": "grok", "defaultModel": "grok-3-latest"},
 		{"id": "kimi", "name": "Kimi (Moonshot)", "provider": "kimi", "defaultModel": "moonshot-v1-auto"},
-		{"id": "minimax", "name": "MiniMax", "provider": "minimax", "defaultModel": "MiniMax-M2.5"},
+		{"id": "minimax", "name": "MiniMax", "provider": "minimax", "defaultModel": "MiniMax-M2.7"},
 		{"id": "claw402", "name": "Claw402 (Base USDC)", "provider": "claw402", "defaultModel": "deepseek"},
 	}
 

--- a/mcp/provider/minimax.go
+++ b/mcp/provider/minimax.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	DefaultMiniMaxBaseURL = "https://api.minimax.io/v1"
-	DefaultMiniMaxModel   = "MiniMax-M2.5"
+	DefaultMiniMaxModel   = "MiniMax-M2.7"
 )
 
 func init() {

--- a/mcp/providers.go
+++ b/mcp/providers.go
@@ -25,5 +25,5 @@ const (
 
 	// Default MiniMax configuration (used by WithMiniMaxConfig convenience option)
 	DefaultMiniMaxBaseURL = "https://api.minimax.io/v1"
-	DefaultMiniMaxModel   = "MiniMax-M2.5"
+	DefaultMiniMaxModel   = "MiniMax-M2.7"
 )

--- a/web/src/components/trader/model-constants.ts
+++ b/web/src/components/trader/model-constants.ts
@@ -91,7 +91,7 @@ export const AI_PROVIDER_CONFIG: Record<string, AIProviderConfig> = {
     apiName: 'Moonshot',
   },
   minimax: {
-    defaultModel: 'MiniMax-M2.5',
+    defaultModel: 'MiniMax-M2.7',
     apiUrl: 'https://platform.minimax.io',
     apiName: 'MiniMax',
   },


### PR DESCRIPTION
## Summary
- Update default MiniMax model from M2.5 to M2.7
- 4 files modified

## Changes
- `mcp/providers.go`: DefaultMiniMaxModel = "MiniMax-M2.7"
- `mcp/provider/minimax.go`: DefaultMiniMaxModel = "MiniMax-M2.7"
- `api/handler_ai_model.go`: defaultModel = "MiniMax-M2.7"
- `web/src/components/trader/model-constants.ts`: defaultModel = 'MiniMax-M2.7'