### PR TITLE
feat: improve beginner onboarding and model config sync

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,7 +23,7 @@ import { AuthProvider, useAuth } from './contexts/AuthContext'
 import { ConfirmDialogProvider } from './components/common/ConfirmDialog'
 import { t } from './i18n/translations'
 import { useSystemConfig } from './hooks/useSystemConfig'
-import { getUserMode, hasCompletedBeginnerOnboarding } from './lib/onboarding'
+import { getUserMode } from './lib/onboarding'
 
 import { OFFICIAL_LINKS } from './constants/branding'
 import type {
@@ -352,7 +352,7 @@ function App() {
   }, [route])
 
   const showBeginnerOnboarding =
-    route === '/welcome' && (!!user || hasPersistedAuth) && getUserMode() === 'beginner' && !hasCompletedBeginnerOnboarding()
+    route === '/welcome' && (!!user || hasPersistedAuth) && getUserMode() === 'beginner'
 
   // Show loading spinner while checking auth or config
   if (isLoading || configLoading) {

--- a/web/src/components/trader/AITradersPage.tsx
+++ b/web/src/components/trader/AITradersPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
 import { api } from '../../lib/api'
@@ -32,6 +32,7 @@ import {
   setBeginnerWalletAddress as persistBeginnerWalletAddress,
 } from '../../lib/onboarding'
 import type { Strategy } from '../../types'
+import { subscribeModelConfigsUpdated } from '../../lib/modelConfigEvents'
 
 interface AITradersPageProps {
   onTraderSelect?: (traderId: string) => void
@@ -55,9 +56,43 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
   const [visibleTraderAddresses, setVisibleTraderAddresses] = useState<Set<string>>(new Set())
   const [visibleExchangeAddresses, setVisibleExchangeAddresses] = useState<Set<string>>(new Set())
   const [copiedId, setCopiedId] = useState<string | null>(null)
-  const [quickSetupLoading, setQuickSetupLoading] = useState(false)
   const [beginnerWalletAddress, setBeginnerWalletAddress] = useState<string | null>(() => getBeginnerWalletAddress())
   const isBeginnerMode = getUserMode() === 'beginner'
+
+  const loadConfigs = useCallback(async () => {
+    if (!user || !token) {
+      try {
+        const models = await api.getSupportedModels()
+        setSupportedModels(models)
+      } catch (err) {
+        console.error('Failed to load supported configs:', err)
+      }
+      return
+    }
+
+    try {
+      const [
+        modelConfigs,
+        exchangeConfigs,
+        models,
+      ] = await Promise.all([
+        api.getModelConfigs(),
+        api.getExchangeConfigs(),
+        api.getSupportedModels(),
+      ])
+      setAllModels(modelConfigs)
+      const clawWalletAddress =
+        modelConfigs.find((model) => model.provider === 'claw402')?.walletAddress || null
+      if (clawWalletAddress) {
+        setBeginnerWalletAddress(clawWalletAddress)
+        persistBeginnerWalletAddress(clawWalletAddress)
+      }
+      setAllExchanges(exchangeConfigs)
+      setSupportedModels(models)
+    } catch (error) {
+      console.error('Failed to load configs:', error)
+    }
+  }, [user, token])
 
   const navigateInApp = (path: string) => {
     navigate(path)
@@ -113,42 +148,14 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
   )
 
   useEffect(() => {
-    const loadConfigs = async () => {
-      if (!user || !token) {
-        try {
-          const models = await api.getSupportedModels()
-          setSupportedModels(models)
-        } catch (err) {
-          console.error('Failed to load supported configs:', err)
-        }
-        return
-      }
+    void loadConfigs()
+  }, [loadConfigs])
 
-      try {
-        const [
-          modelConfigs,
-          exchangeConfigs,
-          models,
-        ] = await Promise.all([
-          api.getModelConfigs(),
-          api.getExchangeConfigs(),
-          api.getSupportedModels(),
-        ])
-        setAllModels(modelConfigs)
-        const clawWalletAddress =
-          modelConfigs.find((model) => model.provider === 'claw402')?.walletAddress || null
-        if (clawWalletAddress) {
-          setBeginnerWalletAddress(clawWalletAddress)
-          persistBeginnerWalletAddress(clawWalletAddress)
-        }
-        setAllExchanges(exchangeConfigs)
-        setSupportedModels(models)
-      } catch (error) {
-        console.error('Failed to load configs:', error)
-      }
-    }
-    loadConfigs()
-  }, [user, token])
+  useEffect(() => {
+    return subscribeModelConfigsUpdated(() => {
+      void loadConfigs()
+    })
+  }, [loadConfigs])
 
   const configuredModels =
     allModels?.filter((m) => {
@@ -472,15 +479,29 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
         return
       }
 
+      let nextApiKey = apiKey
+      let nextCustomModelName = customModelName || ''
+      const isClaw402Model =
+        modelToUpdate.provider === 'claw402' || modelToUpdate.id === 'claw402'
+      const hasExistingClaw402Wallet = Boolean(existingModel?.walletAddress)
+
+      if (isClaw402Model && !apiKey.trim() && !hasExistingClaw402Wallet) {
+        const onboarding = await api.prepareBeginnerOnboarding()
+        nextApiKey = onboarding.private_key
+        nextCustomModelName = customModelName || onboarding.default_model || 'deepseek'
+        persistBeginnerWalletAddress(onboarding.address)
+        setBeginnerWalletAddress(onboarding.address)
+      }
+
       if (existingModel) {
         updatedModels =
           allModels?.map((m) =>
             m.id === modelId
               ? {
                 ...m,
-                apiKey,
+                apiKey: nextApiKey,
                 customApiUrl: customApiUrl || '',
-                customModelName: customModelName || '',
+                customModelName: nextCustomModelName,
                 enabled: true,
               }
               : m
@@ -488,9 +509,9 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
       } else {
         const newModel = {
           ...modelToUpdate,
-          apiKey,
+          apiKey: nextApiKey,
           customApiUrl: customApiUrl || '',
-          customModelName: customModelName || '',
+          customModelName: nextCustomModelName,
           enabled: true,
         }
         updatedModels = [...(allModels || []), newModel]
@@ -642,33 +663,16 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
     setShowExchangeModal(true)
   }
 
-  const handleQuickSetupClaw402 = async () => {
-    if (quickSetupLoading) return
-
-    try {
-      setQuickSetupLoading(true)
-      const result = await api.prepareBeginnerOnboarding()
-      setBeginnerWalletAddress(result.address)
-      const refreshedModels = await api.getModelConfigs()
-      setAllModels(refreshedModels)
-      toast.success(
-        language === 'zh'
-          ? 'Claw402 已默认配置为 DeepSeek'
-          : 'Claw402 is configured with DeepSeek by default'
-      )
-    } catch (error) {
-      console.error('Failed to quick setup claw402:', error)
-      toast.error(
-        language === 'zh'
-          ? '一键配置 Claw402 失败'
-          : 'Failed to quick setup Claw402'
-      )
-    } finally {
-      setQuickSetupLoading(false)
-    }
-  }
-
-  const claw402Configured = configuredModels.some((model) => model.provider === 'claw402')
+  const claw402Configured =
+    Boolean(beginnerWalletAddress) ||
+    allModels.some(
+      (model) =>
+        model.provider === 'claw402' &&
+        (model.enabled ||
+          Boolean(model.walletAddress) ||
+          Boolean(model.balanceUsdc) ||
+          Boolean(model.customModelName))
+    )
   const hasStrategies = (strategies?.length || 0) > 0
   const canCreateTrader = configuredModels.length > 0 && configuredExchanges.length > 0
 
@@ -751,7 +755,7 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
             strategyReady={hasStrategies}
             canCreateTrader={canCreateTrader}
             walletAddress={beginnerWalletAddress}
-            onQuickSetupClaw402={handleQuickSetupClaw402}
+            onOpenModel={handleAddModel}
             onOpenExchange={handleAddExchange}
             onOpenStrategy={() => navigateInApp('/strategy')}
             onCreateTrader={() => setShowCreateModal(true)}

--- a/web/src/components/trader/BeginnerGuideCards.tsx
+++ b/web/src/components/trader/BeginnerGuideCards.tsx
@@ -7,7 +7,7 @@ interface BeginnerGuideCardsProps {
   strategyReady: boolean
   canCreateTrader: boolean
   walletAddress?: string | null
-  onQuickSetupClaw402: () => void
+  onOpenModel: () => void
   onOpenExchange: () => void
   onOpenStrategy: () => void
   onCreateTrader: () => void
@@ -25,7 +25,7 @@ export function BeginnerGuideCards({
   strategyReady,
   canCreateTrader,
   walletAddress,
-  onQuickSetupClaw402,
+  onOpenModel,
   onOpenExchange,
   onOpenStrategy,
   onCreateTrader,
@@ -38,25 +38,21 @@ export function BeginnerGuideCards({
       icon: Brain,
       title: isZh ? '1. 极速模型' : '1. Fast AI',
       desc: isZh
-        ? '默认就是 Claw402 + DeepSeek。第一次不用挑模型，先跑起来。'
-        : 'Start with Claw402 + DeepSeek. No model picking needed for the first run.',
+        ? '打开模型弹窗后直接点保存。首次会自动生成 Claw402 钱包，并默认使用 DeepSeek。'
+        : 'Open the model modal and save directly. Your first save will auto-generate a Claw402 wallet with DeepSeek by default.',
       meta: walletAddress
         ? isZh
           ? `钱包 ${truncateAddress(walletAddress)}`
           : `Wallet ${truncateAddress(walletAddress)}`
         : isZh
-          ? 'Base 链 USDC 按次付费'
-          : 'Pay per call with Base USDC',
+          ? '保存时自动生成 Base 钱包'
+          : 'Saving will auto-generate a Base wallet',
       ready: claw402Ready,
       actionLabel: claw402Ready
-        ? isZh
-          ? '已配置'
-          : 'Configured'
-        : isZh
-          ? '一键配置'
-          : 'One-click setup',
-      onAction: onQuickSetupClaw402,
-      disabled: claw402Ready,
+        ? isZh ? '管理模型' : 'Manage model'
+        : isZh ? '打开模型配置' : 'Open model setup',
+      onAction: onOpenModel,
+      disabled: false,
     },
     {
       key: 'exchange',
@@ -66,20 +62,12 @@ export function BeginnerGuideCards({
         ? '交易所接好以后，AI 才能真正下单。'
         : 'Connect an exchange so the AI can actually place trades.',
       meta: exchangeReady
-        ? isZh
-          ? '已准备好'
-          : 'Ready'
-        : isZh
-          ? 'Binance / OKX / Bybit / Hyperliquid'
-          : 'Binance / OKX / Bybit / Hyperliquid',
+        ? isZh ? '已准备好' : 'Ready'
+        : isZh ? 'Binance / OKX / Bybit / Hyperliquid' : 'Binance / OKX / Bybit / Hyperliquid',
       ready: exchangeReady,
       actionLabel: exchangeReady
-        ? isZh
-          ? '继续管理'
-          : 'Manage'
-        : isZh
-          ? '去配置'
-          : 'Configure',
+        ? isZh ? '继续管理' : 'Manage'
+        : isZh ? '去配置' : 'Configure',
       onAction: onOpenExchange,
       disabled: false,
     },
@@ -91,12 +79,8 @@ export function BeginnerGuideCards({
         ? '先用默认策略也可以，后面再慢慢细调。'
         : 'You can start with a default strategy and fine-tune later.',
       meta: strategyReady
-        ? isZh
-          ? '已有策略可用'
-          : 'Strategy ready'
-        : isZh
-          ? '可选，但建议提前看一眼'
-          : 'Optional, but worth a quick look',
+        ? isZh ? '已有策略可用' : 'Strategy ready'
+        : isZh ? '可选，但建议提前看一眼' : 'Optional, but worth a quick look',
       ready: strategyReady,
       actionLabel: isZh ? '打开策略页' : 'Open strategy',
       onAction: onOpenStrategy,
@@ -110,12 +94,8 @@ export function BeginnerGuideCards({
         ? '最后一步，把模型和交易所绑在一起，就能开始运行。'
         : 'Last step: bind your model and exchange, then start running.',
       meta: canCreateTrader
-        ? isZh
-          ? '已经可以创建'
-          : 'Ready to create'
-        : isZh
-          ? '先完成前两步'
-          : 'Finish the first two steps first',
+        ? isZh ? '已经可以创建' : 'Ready to create'
+        : isZh ? '先完成前两步' : 'Finish the first two steps first',
       ready: canCreateTrader,
       actionLabel: isZh ? '立即创建' : 'Create now',
       onAction: onCreateTrader,
@@ -131,14 +111,12 @@ export function BeginnerGuideCards({
             {isZh ? '新手引导' : 'Quickstart'}
           </div>
           <h2 className="mt-1 text-xl font-bold text-white">
-            {isZh
-              ? '先按这 4 步走，最快上手'
-              : 'Follow these 4 steps to get started fast'}
+            {isZh ? '先按这 4 步走，最快上手' : 'Follow these 4 steps to get started fast'}
           </h2>
         </div>
-        {/* <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-zinc-400">
+        <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-zinc-400">
           {isZh ? '老手模式不会看到这块' : 'Hidden in advanced mode'}
-        </div> */}
+        </div>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -160,19 +138,11 @@ export function BeginnerGuideCards({
                       : 'bg-zinc-800 text-zinc-400'
                   }`}
                 >
-                  {card.ready
-                    ? isZh
-                      ? '已就绪'
-                      : 'Ready'
-                    : isZh
-                      ? '待完成'
-                      : 'Pending'}
+                  {card.ready ? (isZh ? '已就绪' : 'Ready') : (isZh ? '待完成' : 'Pending')}
                 </span>
               </div>
 
-              <h3 className="mt-4 text-base font-semibold text-white">
-                {card.title}
-              </h3>
+              <h3 className="mt-4 text-base font-semibold text-white">{card.title}</h3>
               <p className="mt-2 min-h-[72px] text-sm leading-6 text-zinc-400">
                 {card.desc}
               </p>

--- a/web/src/components/trader/ModelConfigModal.tsx
+++ b/web/src/components/trader/ModelConfigModal.tsx
@@ -13,7 +13,7 @@ import {
   AI_PROVIDER_CONFIG,
   getShortName,
 } from './model-constants'
-import { getBeginnerWalletAddress, getUserMode } from '../../lib/onboarding'
+import { getBeginnerWalletAddress } from '../../lib/onboarding'
 
 interface ModelConfigModalProps {
   allModels: AIModel[]
@@ -77,14 +77,23 @@ export function ModelConfigModal({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!selectedModelId || !apiKey.trim()) return
-    onSave(selectedModelId, apiKey.trim(), baseUrl.trim() || undefined, modelName.trim() || undefined)
+    const trimmedApiKey = apiKey.trim()
+    const canSubmit =
+      Boolean(selectedModelId) &&
+      (isClaw402Selected || Boolean(trimmedApiKey))
+
+    if (!canSubmit || !selectedModelId) return
+    onSave(
+      selectedModelId,
+      trimmedApiKey,
+      baseUrl.trim() || undefined,
+      modelName.trim() || undefined
+    )
   }
 
   const availableModels = allModels || []
   const configuredIds = new Set(configuredModels?.map(m => m.id) || [])
   const isClaw402Selected = selectedModel?.provider === 'claw402' || selectedModel?.id === 'claw402'
-  const isBeginnerDefaultModel = isClaw402Selected && getUserMode() === 'beginner'
   const stepLabels = [
     t('modelConfig.selectModel', language),
     t(
@@ -118,7 +127,7 @@ export function ModelConfigModal({
             </h3>
           </div>
           <div className="flex items-center gap-2">
-            {editingModelId && !isBeginnerDefaultModel && (
+            {editingModelId && (
               <button
                 type="button"
                 onClick={() => onDelete(editingModelId)}
@@ -342,6 +351,7 @@ function Claw402ConfigForm({
   const [testing, setTesting] = useState(false)
   const [serverWalletAddress, setServerWalletAddress] = useState('')
   const [serverWalletBalance, setServerWalletBalance] = useState<string | null>(null)
+  const trimmedApiKey = apiKey.trim()
   const localWalletAddress = getBeginnerWalletAddress()?.trim() || ''
   const configuredWalletAddress =
     configuredModel?.walletAddress?.trim() || localWalletAddress || serverWalletAddress
@@ -359,7 +369,11 @@ function Claw402ConfigForm({
     return ''
   }
 
-  const isKeyValid = apiKey.length === 66 && apiKey.startsWith('0x') && /^0x[0-9a-fA-F]{64}$/.test(apiKey)
+  const isKeyValid =
+    trimmedApiKey.length === 66 &&
+    trimmedApiKey.startsWith('0x') &&
+    /^0x[0-9a-fA-F]{64}$/.test(trimmedApiKey)
+  const canSubmit = !trimmedApiKey || isKeyValid
 
   useEffect(() => {
     if (hasExistingWallet) {
@@ -399,10 +413,10 @@ function Claw402ConfigForm({
     setClaw402Status(null)
     setTestResult(null)
 
-    const clientErr = getClientError(apiKey)
+    const clientErr = getClientError(trimmedApiKey)
     setKeyError(clientErr)
 
-    if (clientErr || !apiKey) {
+    if (clientErr || !trimmedApiKey) {
       setValidating(false)
       return
     }
@@ -413,7 +427,7 @@ function Claw402ConfigForm({
         const res = await fetch('/api/wallet/validate', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ private_key: apiKey }),
+          body: JSON.stringify({ private_key: trimmedApiKey }),
         })
         const data = await res.json()
         if (data.valid) {
@@ -432,13 +446,13 @@ function Claw402ConfigForm({
     }, 500)
 
     return () => clearTimeout(timer)
-  }, [apiKey])
+  }, [trimmedApiKey])
 
   const handleTestConnection = async () => {
     setTesting(true)
     setTestResult(null)
     try {
-      if (!apiKey && hasExistingWallet) {
+      if (!trimmedApiKey && hasExistingWallet) {
         const result = await api.getCurrentBeginnerWallet()
         setClaw402Status(result.claw402_status || 'unknown')
         if (result.found && result.address) {
@@ -458,7 +472,7 @@ function Claw402ConfigForm({
       const res = await fetch('/api/wallet/validate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ private_key: apiKey }),
+        body: JSON.stringify({ private_key: trimmedApiKey }),
       })
       const data = await res.json()
       if (data.valid) {
@@ -643,11 +657,18 @@ function Claw402ConfigForm({
                 border: keyError ? '1px solid #EF4444' : walletAddress ? '1px solid #00E096' : '1px solid #2B3139',
                 color: '#EAECEF',
               }}
-              required={!hasExistingWallet}
             />
           </div>
 
-          {hasExistingWallet && !apiKey ? (
+          {!hasExistingWallet && !trimmedApiKey ? (
+            <div className="text-[11px] leading-5" style={{ color: '#60A5FA' }}>
+              {language === 'zh'
+                ? '首次使用时可以直接点保存，系统会自动为你生成 Claw402 钱包并完成默认配置。'
+                : 'For first-time setup, you can save directly and the app will auto-generate a Claw402 wallet with the default configuration.'}
+            </div>
+          ) : null}
+
+          {hasExistingWallet && !trimmedApiKey ? (
             <div className="text-[11px] leading-5" style={{ color: '#848E9C' }}>
               {language === 'zh'
                 ? '后续这里只使用你第一次创建并保存的钱包；如果你要换钱包，请手动填写新的私钥。'
@@ -664,7 +685,7 @@ function Claw402ConfigForm({
         </div>
 
         {/* Wallet Validation Results */}
-        {(apiKey || hasExistingWallet) && (
+        {(trimmedApiKey || hasExistingWallet) && (
           <div className="space-y-2 pl-1">
             {/* Validating spinner */}
             {validating && (
@@ -762,7 +783,7 @@ function Claw402ConfigForm({
                     </div>
                   </div>
                 )}
-                {!apiKey && hasExistingWallet && (
+                {!trimmedApiKey && hasExistingWallet && (
                   <div className="text-[11px]" style={{ color: '#848E9C' }}>
                     {language === 'zh'
                       ? '当前正在使用这个钱包充值。若要切换钱包，再输入新的私钥并保存即可。'
@@ -833,9 +854,9 @@ function Claw402ConfigForm({
         </button>
         <button
           type="submit"
-          disabled={!isKeyValid}
+          disabled={!canSubmit}
           className="flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-bold transition-all hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed"
-          style={{ background: isKeyValid ? 'linear-gradient(135deg, #2563EB, #7C3AED)' : '#2B3139', color: '#fff' }}
+          style={{ background: canSubmit ? 'linear-gradient(135deg, #2563EB, #7C3AED)' : '#2B3139', color: '#fff' }}
         >
           {'🚀 ' + t('modelConfig.startTrading', language)}
         </button>

--- a/web/src/components/trader/TelegramConfigModal.tsx
+++ b/web/src/components/trader/TelegramConfigModal.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { Check, ChevronLeft, ExternalLink, MessageCircle, Unlink, ArrowRight } from 'lucide-react'
 import { toast } from 'sonner'
 import { api } from '../../lib/api'
 import type { TelegramConfig, AIModel } from '../../types'
 import { t, type Language } from '../../i18n/translations'
 import { NofxSelect } from '../ui/select'
+import { subscribeModelConfigsUpdated } from '../../lib/modelConfigEvents'
 
 // Step indicator (reused pattern from ExchangeConfigModal)
 function StepIndicator({ currentStep, labels }: { currentStep: number; labels: string[] }) {
@@ -56,15 +57,18 @@ export function TelegramConfigModal({ onClose, language }: TelegramConfigModalPr
   const [isLoading, setIsLoading] = useState(true)
   const [isUnbinding, setIsUnbinding] = useState(false)
 
+  const refreshEnabledModels = useCallback(async () => {
+    const allModels = await api.getModelConfigs().catch(() => [] as AIModel[])
+    const enabledModels = allModels.filter((m) => m.enabled)
+    setModels(enabledModels)
+  }, [])
+
   // Load current config and available models
   useEffect(() => {
     Promise.all([
       api.getTelegramConfig().catch(() => null),
-      api.getModelConfigs().catch(() => [] as AIModel[]),
-    ]).then(([cfg, allModels]) => {
-      const enabledModels = allModels.filter((m) => m.enabled)
-      setModels(enabledModels)
-
+      refreshEnabledModels(),
+    ]).then(([cfg]) => {
       if (cfg) {
         setConfig(cfg)
         setSelectedModelId(cfg.model_id ?? '')
@@ -75,7 +79,13 @@ export function TelegramConfigModal({ onClose, language }: TelegramConfigModalPr
         }
       }
     }).finally(() => setIsLoading(false))
-  }, [])
+  }, [refreshEnabledModels])
+
+  useEffect(() => {
+    return subscribeModelConfigsUpdated(() => {
+      void refreshEnabledModels()
+    })
+  }, [refreshEnabledModels])
 
   const handleSaveToken = async () => {
     if (!token.trim()) return

--- a/web/src/lib/api/config.ts
+++ b/web/src/lib/api/config.ts
@@ -8,6 +8,7 @@ import type {
   CurrentBeginnerWalletResponse,
 } from '../../types'
 import { API_BASE, httpClient, CryptoService } from './helpers'
+import { notifyModelConfigsUpdated } from '../modelConfigEvents'
 
 export const configApi = {
   async getModelConfigs(): Promise<AIModel[]> {
@@ -42,6 +43,7 @@ export const configApi = {
       // Transport encryption disabled, send plaintext
       const result = await httpClient.put(`${API_BASE}/models`, request)
       if (!result.success) throw new Error('Failed to update model configs')
+      notifyModelConfigsUpdated()
       return
     }
 
@@ -65,6 +67,7 @@ export const configApi = {
     // Send encrypted data
     const result = await httpClient.put(`${API_BASE}/models`, encryptedPayload)
     if (!result.success) throw new Error('Failed to update model configs')
+    notifyModelConfigsUpdated()
   },
 
   async getExchangeConfigs(): Promise<Exchange[]> {
@@ -193,6 +196,7 @@ export const configApi = {
     if (!result.success || !result.data) {
       throw new Error(result.message || 'Failed to prepare beginner onboarding')
     }
+    notifyModelConfigsUpdated()
     return result.data
   },
 

--- a/web/src/lib/modelConfigEvents.ts
+++ b/web/src/lib/modelConfigEvents.ts
@@ -1,0 +1,24 @@
+const MODEL_CONFIGS_UPDATED_EVENT = 'nofx:model-configs-updated'
+
+export function notifyModelConfigsUpdated() {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.dispatchEvent(new CustomEvent(MODEL_CONFIGS_UPDATED_EVENT))
+}
+
+export function subscribeModelConfigsUpdated(
+  listener: () => void
+): () => void {
+  if (typeof window === 'undefined') {
+    return () => {}
+  }
+
+  const handler: EventListener = () => listener()
+  window.addEventListener(MODEL_CONFIGS_UPDATED_EVENT, handler)
+
+  return () => {
+    window.removeEventListener(MODEL_CONFIGS_UPDATED_EVENT, handler)
+  }
+}

--- a/web/src/lib/onboarding.ts
+++ b/web/src/lib/onboarding.ts
@@ -2,7 +2,6 @@ export type UserMode = 'beginner' | 'advanced'
 
 const USER_MODE_KEY = 'nofx_user_mode'
 const BEGINNER_WALLET_ADDRESS_KEY = 'nofx_beginner_wallet_address'
-const BEGINNER_ONBOARDING_COMPLETED_KEY = 'nofx_beginner_onboarding_completed'
 
 export function getUserMode(): UserMode | null {
   const value = localStorage.getItem(USER_MODE_KEY)
@@ -26,12 +25,4 @@ export function setBeginnerWalletAddress(address: string) {
 
 export function getBeginnerWalletAddress(): string | null {
   return localStorage.getItem(BEGINNER_WALLET_ADDRESS_KEY)
-}
-
-export function hasCompletedBeginnerOnboarding(): boolean {
-  return localStorage.getItem(BEGINNER_ONBOARDING_COMPLETED_KEY) === 'true'
-}
-
-export function markBeginnerOnboardingCompleted() {
-  localStorage.setItem(BEGINNER_ONBOARDING_COMPLETED_KEY, 'true')
 }

--- a/web/src/pages/BeginnerOnboardingPage.tsx
+++ b/web/src/pages/BeginnerOnboardingPage.tsx
@@ -12,7 +12,7 @@ import { toast } from 'sonner'
 import { useLanguage } from '../contexts/LanguageContext'
 import { api } from '../lib/api'
 import type { BeginnerOnboardingResponse } from '../types'
-import { setBeginnerWalletAddress, markBeginnerOnboardingCompleted } from '../lib/onboarding'
+import { setBeginnerWalletAddress } from '../lib/onboarding'
 
 export function BeginnerOnboardingPage() {
   const { language } = useLanguage()
@@ -78,7 +78,6 @@ export function BeginnerOnboardingPage() {
   }
 
   const handleContinue = () => {
-    markBeginnerOnboardingCompleted()
     window.history.pushState({}, '', '/traders')
     window.dispatchEvent(new PopStateEvent('popstate'))
   }

--- a/web/src/pages/StrategyStudioPage.tsx
+++ b/web/src/pages/StrategyStudioPage.tsx
@@ -41,6 +41,7 @@ import { GridConfigEditor, defaultGridConfig } from '../components/strategy/Grid
 import { TokenEstimateBar } from '../components/strategy/TokenEstimateBar'
 import { DeepVoidBackground } from '../components/common/DeepVoidBackground'
 import { t } from '../i18n/translations'
+import { subscribeModelConfigsUpdated } from '../lib/modelConfigEvents'
 
 const API_BASE = import.meta.env.VITE_API_BASE || ''
 
@@ -155,6 +156,12 @@ export function StrategyStudioPage() {
     fetchStrategies()
     fetchAiModels()
   }, [fetchStrategies, fetchAiModels])
+
+  useEffect(() => {
+    return subscribeModelConfigsUpdated(() => {
+      void fetchAiModels()
+    })
+  }, [fetchAiModels])
 
   // Track previous language to detect actual changes
   const prevLanguageRef = useRef(language)
@@ -328,7 +335,10 @@ export function StrategyStudioPage() {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
       })
-      if (!response.ok) throw new Error('Failed to activate strategy')
+      if (!response.ok) {
+        const data = await response.json().catch(() => null)
+        throw new Error(data?.error || 'Failed to activate strategy')
+      }
       await fetchStrategies()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error')


### PR DESCRIPTION
## Summary

This PR uploads the full current `nofx-dev-week1` frontend onboarding and model configuration updates on top of `dev`.

The main goal is to make the beginner model setup flow consistent and remove refresh-dependent UI behavior after model configuration changes.

## What Changed

### Beginner onboarding flow

- beginner mode now shows the welcome onboarding route consistently instead of depending on a separate persisted completion flag
- the old local `beginner_onboarding_completed` flag helpers were removed
- continuing from the beginner onboarding page now relies on navigation flow instead of writing that extra local completion flag

### Claw402 first-time setup

- saving the Claw402 model modal now auto-runs the existing beginner onboarding preparation flow when no wallet exists yet
- first-time users no longer need a separate one-click generation step after pressing save
- the returned beginner wallet address is persisted and reused in the trader page state
- the default beginner model is set to `deepseek`

### Model configuration sync without refresh

- added a lightweight `model-configs-updated` event helper
- model updates and beginner onboarding preparation now emit that event
- the following screens now reactively refresh model-dependent UI without a manual page reload:
  - AI traders page and AI model status panel
  - strategy studio model list
  - Telegram config modal

### Beginner guide copy

- updated the beginner guide so it points users to open the model modal and save directly
- removed the misleading separate one-click setup wording now that save already completes first-time setup

### Claw402 modal UX

- first-time Claw402 save is allowed even without a manually entered private key
- helper copy explains that the wallet will be auto-generated on first save
- validation and submit button state now support both existing-wallet reuse and first-time auto-generation

### Strategy activation error handling

- strategy activation now surfaces backend error messages instead of always showing a generic failure message

## Testing

- `docker compose build nofx-frontend`

## Notes

- This PR is intended to represent the current full state of the `nofx-dev-week1` workspace for these onboarding and model-sync related changes.
