### PR TITLE
fix: improve trader error feedback and balance validation UX

### DIFF
--- a/api/exchange_balance.go
+++ b/api/exchange_balance.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"fmt"
+
+	"nofx/store"
+	"nofx/trader"
+	"nofx/trader/aster"
+	"nofx/trader/binance"
+	"nofx/trader/bitget"
+	"nofx/trader/bybit"
+	"nofx/trader/gate"
+	hyperliquidtrader "nofx/trader/hyperliquid"
+	"nofx/trader/kucoin"
+	"nofx/trader/lighter"
+	"nofx/trader/okx"
+)
+
+func buildBalanceQueryTrader(exchangeCfg *store.Exchange, userID string) (trader.Trader, error) {
+	switch exchangeCfg.ExchangeType {
+	case "binance":
+		return binance.NewFuturesTrader(string(exchangeCfg.APIKey), string(exchangeCfg.SecretKey), userID), nil
+	case "hyperliquid":
+		return hyperliquidtrader.NewHyperliquidTrader(
+			string(exchangeCfg.APIKey),
+			exchangeCfg.HyperliquidWalletAddr,
+			exchangeCfg.Testnet,
+			exchangeCfg.HyperliquidUnifiedAcct,
+		)
+	case "aster":
+		return aster.NewAsterTrader(
+			exchangeCfg.AsterUser,
+			exchangeCfg.AsterSigner,
+			string(exchangeCfg.AsterPrivateKey),
+		)
+	case "bybit":
+		return bybit.NewBybitTrader(
+			string(exchangeCfg.APIKey),
+			string(exchangeCfg.SecretKey),
+		), nil
+	case "okx":
+		return okx.NewOKXTrader(
+			string(exchangeCfg.APIKey),
+			string(exchangeCfg.SecretKey),
+			string(exchangeCfg.Passphrase),
+		), nil
+	case "bitget":
+		return bitget.NewBitgetTrader(
+			string(exchangeCfg.APIKey),
+			string(exchangeCfg.SecretKey),
+			string(exchangeCfg.Passphrase),
+		), nil
+	case "gate":
+		return gate.NewGateTrader(
+			string(exchangeCfg.APIKey),
+			string(exchangeCfg.SecretKey),
+		), nil
+	case "kucoin":
+		return kucoin.NewKuCoinTrader(
+			string(exchangeCfg.APIKey),
+			string(exchangeCfg.SecretKey),
+			string(exchangeCfg.Passphrase),
+		), nil
+	case "lighter":
+		if exchangeCfg.LighterWalletAddr != "" && string(exchangeCfg.LighterAPIKeyPrivateKey) != "" {
+			return lighter.NewLighterTraderV2(
+				exchangeCfg.LighterWalletAddr,
+				string(exchangeCfg.LighterAPIKeyPrivateKey),
+				exchangeCfg.LighterAPIKeyIndex,
+				false,
+			)
+		}
+		return nil, fmt.Errorf("Lighter requires wallet address and API Key private key")
+	default:
+		return nil, fmt.Errorf("unsupported exchange type: %s", exchangeCfg.ExchangeType)
+	}
+}
+
+func extractExchangeEquity(balanceInfo map[string]interface{}) float64 {
+	balanceKeys := []string{"total_equity", "totalWalletBalance", "wallet_balance", "totalEq", "balance"}
+	for _, key := range balanceKeys {
+		if balance, ok := balanceInfo[key].(float64); ok && balance > 0 {
+			return balance
+		}
+	}
+	return 0
+}
+
+func queryExchangeEquity(exchangeCfg *store.Exchange, userID string) (float64, error) {
+	if exchangeCfg == nil {
+		return 0, fmt.Errorf("exchange config is nil")
+	}
+
+	tempTrader, err := buildBalanceQueryTrader(exchangeCfg, userID)
+	if err != nil {
+		return 0, err
+	}
+
+	balanceInfo, err := tempTrader.GetBalance()
+	if err != nil {
+		return 0, err
+	}
+
+	actualBalance := extractExchangeEquity(balanceInfo)
+	if actualBalance <= 0 {
+		return 0, fmt.Errorf("unable to get total equity")
+	}
+
+	return actualBalance, nil
+}

--- a/api/handler_exchange.go
+++ b/api/handler_exchange.go
@@ -8,6 +8,7 @@ import (
 	"nofx/config"
 	"nofx/crypto"
 	"nofx/logger"
+	"nofx/store"
 
 	"github.com/gin-gonic/gin"
 )
@@ -114,6 +115,58 @@ func (s *Server) handleGetExchangeConfigs(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, safeExchanges)
+}
+
+// handleGetExchangeBalance gets the current equity balance for a specific exchange account.
+func (s *Server) handleGetExchangeBalance(c *gin.Context) {
+	userID := c.GetString("user_id")
+	exchangeID := c.Param("id")
+
+	exchanges, err := s.store.Exchange().List(userID)
+	if err != nil {
+		SafeInternalError(c, "Failed to get exchange configs", err)
+		return
+	}
+
+	var exchangeCfg *store.Exchange
+	for _, exchange := range exchanges {
+		if exchange.ID == exchangeID {
+			exchangeCfg = exchange
+			break
+		}
+	}
+
+	if exchangeCfg == nil {
+		SafeBadRequest(c, "未找到你选择的交易所账户")
+		return
+	}
+
+	if !exchangeCfg.Enabled {
+		SafeBadRequest(c, fmt.Sprintf("交易所账户「%s」目前还没有启用", exchangeDisplayName(exchangeCfg)))
+		return
+	}
+
+	balance, balanceErr := queryExchangeEquity(exchangeCfg, userID)
+	if balanceErr != nil {
+		SafeBadRequest(c, formatTraderStartError(
+			fmt.Sprintf("暂时无法读取交易所账户「%s」的余额", exchangeDisplayName(exchangeCfg)),
+			"请检查该交易所的 API、钱包地址和网络连通性后，再重试",
+		))
+		return
+	}
+
+	if balance <= 0 {
+		SafeBadRequest(c, formatTraderStartError(
+			fmt.Sprintf("交易所账户「%s」当前没有可用余额", exchangeDisplayName(exchangeCfg)),
+			"请先确认该账户有资金，或切换到其他有余额的交易所账户",
+		))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"balance": balance,
+	})
 }
 
 // handleUpdateExchangeConfigs Update exchange configurations (supports both encrypted and plain text based on config)

--- a/api/handler_trader.go
+++ b/api/handler_trader.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	"nofx/trader/okx"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 // AI trader management related structures
@@ -62,22 +64,219 @@ type UpdateTraderRequest struct {
 	SystemPromptTemplate string `json:"system_prompt_template"`
 }
 
+func formatTraderCreationError(reason, nextStep string) string {
+	if nextStep == "" {
+		return fmt.Sprintf("这次未能创建机器人：%s。", reason)
+	}
+	return fmt.Sprintf("这次未能创建机器人：%s。%s。", reason, nextStep)
+}
+
+func traderCreationRequestError(reason string) string {
+	return formatTraderCreationError(reason, "请检查你刚刚填写的内容后，再重新提交")
+}
+
+func exchangeDisplayName(exchange *store.Exchange) string {
+	if exchange == nil {
+		return "所选交易所账户"
+	}
+	if exchange.AccountName != "" {
+		return fmt.Sprintf("%s（%s）", exchange.Name, exchange.AccountName)
+	}
+	if exchange.Name != "" {
+		return exchange.Name
+	}
+	return "所选交易所账户"
+}
+
+func missingExchangeFields(exchange *store.Exchange) []string {
+	if exchange == nil {
+		return nil
+	}
+
+	var missing []string
+	switch exchange.ExchangeType {
+	case "binance", "bybit", "gate", "indodax":
+		if exchange.APIKey == "" {
+			missing = append(missing, "API Key")
+		}
+		if exchange.SecretKey == "" {
+			missing = append(missing, "Secret Key")
+		}
+	case "okx", "bitget", "kucoin":
+		if exchange.APIKey == "" {
+			missing = append(missing, "API Key")
+		}
+		if exchange.SecretKey == "" {
+			missing = append(missing, "Secret Key")
+		}
+		if exchange.Passphrase == "" {
+			missing = append(missing, "Passphrase")
+		}
+	case "hyperliquid":
+		if exchange.APIKey == "" {
+			missing = append(missing, "私钥")
+		}
+		if strings.TrimSpace(exchange.HyperliquidWalletAddr) == "" {
+			missing = append(missing, "钱包地址")
+		}
+	case "aster":
+		if strings.TrimSpace(exchange.AsterUser) == "" {
+			missing = append(missing, "Aster User")
+		}
+		if strings.TrimSpace(exchange.AsterSigner) == "" {
+			missing = append(missing, "Aster Signer")
+		}
+		if exchange.AsterPrivateKey == "" {
+			missing = append(missing, "Aster Private Key")
+		}
+	case "lighter":
+		if strings.TrimSpace(exchange.LighterWalletAddr) == "" {
+			missing = append(missing, "钱包地址")
+		}
+		if exchange.LighterAPIKeyPrivateKey == "" {
+			missing = append(missing, "API Key Private Key")
+		}
+	}
+
+	return missing
+}
+
+func validateExchangeForTraderCreation(exchange *store.Exchange) string {
+	if exchange == nil {
+		return formatTraderCreationError("还没有找到你选择的交易所账户", "请前往「设置 > 交易所配置」先添加一个可用账户，再回来创建机器人")
+	}
+	if !exchange.Enabled {
+		return formatTraderCreationError(
+			fmt.Sprintf("交易所账户「%s」目前处于未启用状态", exchangeDisplayName(exchange)),
+			"请前往「设置 > 交易所配置」启用该账户后，再重新创建机器人",
+		)
+	}
+
+	missing := missingExchangeFields(exchange)
+	if len(missing) > 0 {
+		return formatTraderCreationError(
+			fmt.Sprintf("交易所账户「%s」的配置还不完整，缺少 %s", exchangeDisplayName(exchange), strings.Join(missing, "、")),
+			"请前往「设置 > 交易所配置」补全该账户的必填信息后，再重新创建机器人",
+		)
+	}
+
+	switch exchange.ExchangeType {
+	case "binance", "bybit", "okx", "bitget", "gate", "kucoin", "hyperliquid", "aster", "lighter", "indodax":
+		return ""
+	default:
+		return formatTraderCreationError(
+			fmt.Sprintf("交易所账户「%s」使用了当前版本暂不支持的类型 %s", exchangeDisplayName(exchange), exchange.ExchangeType),
+			"请改用当前版本支持的交易所账户后，再重新创建机器人",
+		)
+	}
+}
+
+func humanizeTraderSetupReason(reason string) string {
+	trimmed := strings.TrimSpace(reason)
+	if trimmed == "" {
+		return ""
+	}
+
+	lower := strings.ToLower(trimmed)
+
+	switch {
+	case strings.Contains(lower, "failed to parse strategy config"),
+		strings.Contains(lower, "failed to parse strategy configuration"):
+		return "当前策略配置内容已损坏，系统暂时无法解析"
+	case strings.Contains(lower, "has no strategy configured"):
+		return "当前机器人缺少有效的交易策略配置"
+	case strings.Contains(lower, "failed to parse private key"),
+		(strings.Contains(lower, "invalid hex character") && strings.Contains(lower, "private key")):
+		return "私钥格式不正确，系统无法识别"
+	case strings.Contains(lower, "failed to initialize hyperliquid trader"):
+		return "Hyperliquid 账户初始化失败，请确认私钥、主钱包地址和 Agent Wallet 配置是否正确"
+	case strings.Contains(lower, "failed to initialize aster trader"):
+		return "Aster 账户初始化失败，请确认 Aster User、Signer 和私钥是否正确"
+	case strings.Contains(lower, "failed to get meta information"):
+		return "系统暂时无法从交易所读取账户元信息"
+	case strings.Contains(lower, "security check failed") && strings.Contains(lower, "agent wallet balance too high"):
+		return "Hyperliquid Agent Wallet 余额过高，不符合当前安全要求"
+	case strings.Contains(lower, "failed to initialize account"):
+		return "交易所账户初始化失败，请确认钱包地址和 API Key 是否匹配"
+	case strings.Contains(lower, "unsupported trading platform"):
+		return "当前交易所类型暂不支持机器人初始化"
+	case strings.Contains(lower, "initial balance not set and unable to fetch balance from exchange"):
+		return "系统暂时无法从交易所读取账户余额"
+	case strings.Contains(lower, "timeout"), strings.Contains(lower, "no such host"), strings.Contains(lower, "connection refused"):
+		return "系统暂时无法连接交易所服务"
+	default:
+		return trimmed
+	}
+}
+
+func describeTraderLoadError(traderName string, err error) string {
+	if err == nil {
+		return formatTraderCreationError("机器人配置虽然保存了，但运行实例没有成功初始化", "请检查模型、策略和交易所配置是否完整，然后再试一次")
+	}
+
+	reason := humanizeTraderSetupReason(SanitizeError(err, ""))
+	if reason == "" {
+		return formatTraderCreationError(
+			fmt.Sprintf("机器人「%s」在初始化运行实例时没有成功启动", traderName),
+			"请检查模型、策略和交易所配置是否完整，然后再试一次",
+		)
+	}
+
+	return formatTraderCreationError(
+		fmt.Sprintf("机器人「%s」在初始化运行实例时没有成功启动，原因是：%s", traderName, reason),
+		"请检查模型、策略和交易所配置是否完整，然后再试一次",
+	)
+}
+
+func describeTraderCreationWarning(traderName string, err error) string {
+	if err == nil {
+		return fmt.Sprintf("机器人「%s」已经保存，但当前还没有通过启动前校验。请先检查模型、策略和交易所配置，修正后再点击启动。", traderName)
+	}
+
+	reason := humanizeTraderSetupReason(SanitizeError(err, ""))
+	if reason == "" {
+		return fmt.Sprintf("机器人「%s」已经保存，但当前暂时还不能启动。请先检查模型、策略和交易所配置，修正后再点击启动。", traderName)
+	}
+
+	return fmt.Sprintf("机器人「%s」已经保存，但当前暂时还不能启动，原因是：%s。请先检查模型、策略和交易所配置，修正后再点击启动。", traderName, reason)
+}
+
+func describeTraderStartError(traderName string, err error) string {
+	if err == nil {
+		return fmt.Sprintf("这次未能启动机器人：机器人「%s」暂时还不能启动。请检查模型、策略和交易所配置后，再重新点击启动。", traderName)
+	}
+
+	reason := humanizeTraderSetupReason(SanitizeError(err, ""))
+	if reason == "" {
+		return fmt.Sprintf("这次未能启动机器人：机器人「%s」暂时还不能启动。请检查模型、策略和交易所配置后，再重新点击启动。", traderName)
+	}
+
+	return fmt.Sprintf("这次未能启动机器人：机器人「%s」暂时还不能启动，原因是：%s。请检查模型、策略和交易所配置后，再重新点击启动。", traderName, reason)
+}
+
+func formatTraderStartError(reason, nextStep string) string {
+	if nextStep == "" {
+		return fmt.Sprintf("这次未能启动机器人：%s。", reason)
+	}
+	return fmt.Sprintf("这次未能启动机器人：%s。%s。", reason, nextStep)
+}
+
 // handleCreateTrader Create new AI trader
 func (s *Server) handleCreateTrader(c *gin.Context) {
 	userID := c.GetString("user_id")
 	var req CreateTraderRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		SafeBadRequest(c, "Invalid request parameters")
+		SafeBadRequest(c, traderCreationRequestError("提交的信息不完整，或者格式不正确"))
 		return
 	}
 
 	// Validate leverage values
 	if req.BTCETHLeverage < 0 || req.BTCETHLeverage > 50 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "BTC/ETH leverage must be between 1-50x"})
+		SafeBadRequest(c, traderCreationRequestError("BTC/ETH 杠杆倍数需要在 1 到 50 倍之间"))
 		return
 	}
 	if req.AltcoinLeverage < 0 || req.AltcoinLeverage > 20 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Altcoin leverage must be between 1-20x"})
+		SafeBadRequest(c, traderCreationRequestError("山寨币杠杆倍数需要在 1 到 20 倍之间"))
 		return
 	}
 
@@ -87,9 +286,58 @@ func (s *Server) handleCreateTrader(c *gin.Context) {
 		for _, symbol := range symbols {
 			symbol = strings.TrimSpace(symbol)
 			if symbol != "" && !strings.HasSuffix(strings.ToUpper(symbol), "USDT") {
-				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid symbol format: %s, must end with USDT", symbol)})
+				SafeBadRequest(c, traderCreationRequestError(
+					fmt.Sprintf("交易对 %s 的格式不正确，目前只支持以 USDT 结尾的合约交易对", symbol),
+				))
 				return
 			}
+		}
+	}
+
+	model, err := s.store.AIModel().Get(userID, req.AIModelID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			SafeBadRequest(c, formatTraderCreationError("还没有找到你选择的 AI 模型", "请前往「设置 > 模型配置」先添加并启用一个可用模型，再回来创建机器人"))
+			return
+		}
+		SafeError(c, http.StatusInternalServerError,
+			formatTraderCreationError("暂时无法读取你的 AI 模型配置", "请稍后重试；如果问题持续，再检查本地服务是否正常"),
+			err,
+		)
+		return
+	}
+	if !model.Enabled {
+		SafeBadRequest(c, formatTraderCreationError(
+			fmt.Sprintf("AI 模型「%s」目前还没有启用", model.Name),
+			"请前往「设置 > 模型配置」启用它后，再重新创建机器人",
+		))
+		return
+	}
+	if model.APIKey == "" {
+		SafeBadRequest(c, formatTraderCreationError(
+			fmt.Sprintf("AI 模型「%s」缺少 API Key 或支付凭证", model.Name),
+			"请前往「设置 > 模型配置」补全模型凭证后，再重新创建机器人",
+		))
+		return
+	}
+
+	if req.StrategyID == "" {
+		SafeBadRequest(c, formatTraderCreationError("你还没有选择交易策略", "请先选择一个策略，再继续创建机器人"))
+		return
+	}
+
+	if req.StrategyID != "" {
+		_, err = s.store.Strategy().Get(userID, req.StrategyID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				SafeBadRequest(c, formatTraderCreationError("你选择的策略不存在，或者已经被删除了", "请重新选择一个可用策略后，再继续创建机器人"))
+				return
+			}
+			SafeError(c, http.StatusInternalServerError,
+				formatTraderCreationError("暂时无法读取你选择的策略配置", "请稍后重试；如果问题持续，再检查本地服务是否正常"),
+				err,
+			)
+			return
 		}
 	}
 
@@ -137,7 +385,11 @@ func (s *Server) handleCreateTrader(c *gin.Context) {
 	actualBalance := req.InitialBalance // Default to use user input
 	exchanges, err := s.store.Exchange().List(userID)
 	if err != nil {
-		logger.Infof("⚠️ Failed to get exchange config, using user input for initial balance: %v", err)
+		SafeError(c, http.StatusInternalServerError,
+			formatTraderCreationError("暂时无法读取你的交易所配置", "请稍后重试；如果问题持续，再检查本地服务是否正常"),
+			err,
+		)
+		return
 	}
 
 	// Find matching exchange configuration
@@ -150,10 +402,15 @@ func (s *Server) handleCreateTrader(c *gin.Context) {
 	}
 
 	if exchangeCfg == nil {
-		logger.Infof("⚠️ Exchange %s configuration not found, using user input for initial balance", req.ExchangeID)
-	} else if !exchangeCfg.Enabled {
-		logger.Infof("⚠️ Exchange %s not enabled, using user input for initial balance", req.ExchangeID)
-	} else {
+		SafeBadRequest(c, validateExchangeForTraderCreation(exchangeCfg))
+		return
+	}
+	if exchangeMsg := validateExchangeForTraderCreation(exchangeCfg); exchangeMsg != "" {
+		SafeBadRequest(c, exchangeMsg)
+		return
+	}
+
+	{
 		// Create temporary trader based on exchange type to query balance
 		var tempTrader trader.Trader
 		var createErr error
@@ -216,12 +473,14 @@ func (s *Server) handleCreateTrader(c *gin.Context) {
 			} else {
 				createErr = fmt.Errorf("Lighter requires wallet address and API Key private key")
 			}
-		default:
-			logger.Infof("⚠️ Unsupported exchange type: %s, using user input for initial balance", exchangeCfg.ExchangeType)
 		}
 
 		if createErr != nil {
-			logger.Infof("⚠️ Failed to create temporary trader, using user input for initial balance: %v", createErr)
+			SafeBadRequest(c, formatTraderCreationError(
+				fmt.Sprintf("交易所账户「%s」没有通过初始化校验，原因是：%s", exchangeDisplayName(exchangeCfg), humanizeTraderSetupReason(SanitizeError(createErr, "配置校验未通过"))),
+				"请前往「设置 > 交易所配置」检查这个账户的密钥、地址和账户信息是否填写正确",
+			))
+			return
 		} else if tempTrader != nil {
 			// Query actual balance
 			balanceInfo, balanceErr := tempTrader.GetBalance()
@@ -275,27 +534,48 @@ func (s *Server) handleCreateTrader(c *gin.Context) {
 	err = s.store.Trader().Create(traderRecord)
 	if err != nil {
 		logger.Infof("❌ Failed to create trader: %v", err)
-		SafeInternalError(c, "Failed to create trader", err)
+		publicMsg := SanitizeError(err, formatTraderCreationError("机器人配置没有保存成功", "请检查名称、模型、策略和交易所配置后，再试一次"))
+		statusCode := http.StatusBadRequest
+		if publicMsg == formatTraderCreationError("机器人配置没有保存成功", "请检查名称、模型、策略和交易所配置后，再试一次") {
+			statusCode = http.StatusInternalServerError
+		}
+		SafeError(c, statusCode, publicMsg, err)
 		return
 	}
 	logger.Infof("🔧 DEBUG: CreateTrader succeeded")
 
 	// Immediately load new trader into TraderManager
 	logger.Infof("🔧 DEBUG: Preparing to call LoadUserTraders")
+	startupWarning := ""
 	err = s.traderManager.LoadUserTradersFromStore(s.store, userID)
 	if err != nil {
 		logger.Infof("⚠️ Failed to load user traders into memory: %v", err)
-		// Don't return error here since trader was successfully created in database
+		startupWarning = describeTraderCreationWarning(req.Name, err)
 	}
 	logger.Infof("🔧 DEBUG: LoadUserTraders completed")
+
+	if startupWarning == "" {
+		if loadErr := s.traderManager.GetLoadError(traderID); loadErr != nil {
+		logger.Infof("⚠️ Trader %s failed to load after creation: %v", traderID, loadErr)
+			startupWarning = describeTraderCreationWarning(req.Name, loadErr)
+		}
+	}
+
+	if startupWarning == "" {
+		if _, getErr := s.traderManager.GetTrader(traderID); getErr != nil {
+		logger.Infof("⚠️ Trader %s not found in memory after creation: %v", traderID, getErr)
+			startupWarning = describeTraderCreationWarning(req.Name, getErr)
+		}
+	}
 
 	logger.Infof("✓ Trader created successfully: %s (model: %s, exchange: %s)", req.Name, req.AIModelID, req.ExchangeID)
 
 	c.JSON(http.StatusCreated, gin.H{
-		"trader_id":   traderID,
-		"trader_name": req.Name,
-		"ai_model":    req.AIModelID,
-		"is_running":  false,
+		"trader_id":        traderID,
+		"trader_name":      req.Name,
+		"ai_model":         req.AIModelID,
+		"is_running":       false,
+		"startup_warning":  startupWarning,
 	})
 }
 
@@ -373,6 +653,17 @@ func (s *Server) handleUpdateTrader(c *gin.Context) {
 		strategyID = existingTrader.StrategyID
 	}
 
+	exchangeChanged := req.ExchangeID != "" && req.ExchangeID != existingTrader.ExchangeID
+	resetInitialBalance := exchangeChanged && req.InitialBalance <= 0
+
+	initialBalance := existingTrader.InitialBalance
+	if req.InitialBalance > 0 {
+		initialBalance = req.InitialBalance
+	}
+	if resetInitialBalance {
+		initialBalance = 0
+	}
+
 	// Update trader configuration
 	traderRecord := &store.Trader{
 		ID:                   traderID,
@@ -381,7 +672,7 @@ func (s *Server) handleUpdateTrader(c *gin.Context) {
 		AIModelID:            req.AIModelID,
 		ExchangeID:           req.ExchangeID,
 		StrategyID:           strategyID, // Associated strategy ID
-		InitialBalance:       req.InitialBalance,
+		InitialBalance:       initialBalance,
 		BTCETHLeverage:       btcEthLeverage,
 		AltcoinLeverage:      altcoinLeverage,
 		TradingSymbols:       req.TradingSymbols,
@@ -411,6 +702,14 @@ func (s *Server) handleUpdateTrader(c *gin.Context) {
 	if err != nil {
 		SafeInternalError(c, "Failed to update trader", err)
 		return
+	}
+
+	if resetInitialBalance {
+		logger.Infof("🔄 Exchange changed for trader %s, resetting stale initial_balance to 0", traderID)
+		if err := s.store.Trader().UpdateInitialBalance(userID, traderID, 0); err != nil {
+			SafeInternalError(c, "Failed to reset trader initial balance", err)
+			return
+		}
 	}
 
 	// Remove old trader from memory first (this also stops if running)
@@ -478,10 +777,14 @@ func (s *Server) handleStartTrader(c *gin.Context) {
 	traderID := c.Param("id")
 
 	// Verify trader belongs to current user
-	_, err := s.store.Trader().GetFullConfig(userID, traderID)
+	fullCfg, err := s.store.Trader().GetFullConfig(userID, traderID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Trader does not exist or no access permission"})
 		return
+	}
+	traderName := traderID
+	if fullCfg != nil && fullCfg.Trader != nil && fullCfg.Trader.Name != "" {
+		traderName = fullCfg.Trader.Name
 	}
 
 	// Check if trader exists in memory and if it's running
@@ -501,45 +804,49 @@ func (s *Server) handleStartTrader(c *gin.Context) {
 	logger.Infof("🔄 Loading trader %s from database...", traderID)
 	if loadErr := s.traderManager.LoadUserTradersFromStore(s.store, userID); loadErr != nil {
 		logger.Infof("❌ Failed to load user traders: %v", loadErr)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load trader: " + loadErr.Error()})
+		SafeError(c, http.StatusInternalServerError, describeTraderStartError(traderName, loadErr), loadErr)
 		return
 	}
 
 	trader, err := s.traderManager.GetTrader(traderID)
 	if err != nil {
-		// Check detailed reason
-		fullCfg, _ := s.store.Trader().GetFullConfig(userID, traderID)
 		if fullCfg != nil && fullCfg.Trader != nil {
 			// Check strategy
 			if fullCfg.Strategy == nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Trader has no strategy configured, please create a strategy in Strategy Studio and associate it with the trader"})
+				SafeBadRequest(c, describeTraderStartError(traderName, fmt.Errorf("trader has no strategy configured")))
 				return
 			}
 			// Check AI model
 			if fullCfg.AIModel == nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Trader's AI model does not exist, please check AI model configuration"})
+				SafeBadRequest(c, formatTraderStartError("这个机器人关联的 AI 模型不存在", "请前往「设置 > 模型配置」检查后，再重新点击启动"))
 				return
 			}
 			if !fullCfg.AIModel.Enabled {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Trader's AI model is not enabled, please enable the AI model first"})
+				SafeBadRequest(c, formatTraderStartError(
+					fmt.Sprintf("机器人「%s」关联的 AI 模型「%s」目前还没有启用", traderName, fullCfg.AIModel.Name),
+					"请前往「设置 > 模型配置」启用它后，再重新点击启动",
+				))
 				return
 			}
 			// Check exchange
 			if fullCfg.Exchange == nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Trader's exchange does not exist, please check exchange configuration"})
+				SafeBadRequest(c, formatTraderStartError("这个机器人关联的交易所账户不存在", "请前往「设置 > 交易所配置」检查后，再重新点击启动"))
 				return
 			}
 			if !fullCfg.Exchange.Enabled {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Trader's exchange is not enabled, please enable the exchange first"})
+				SafeBadRequest(c, formatTraderStartError(
+					fmt.Sprintf("机器人「%s」关联的交易所账户「%s」目前还没有启用", traderName, exchangeDisplayName(fullCfg.Exchange)),
+					"请前往「设置 > 交易所配置」启用它后，再重新点击启动",
+				))
 				return
 			}
 		}
 		// Check if there's a specific load error
 		if loadErr := s.traderManager.GetLoadError(traderID); loadErr != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load trader: " + loadErr.Error()})
+			SafeBadRequest(c, describeTraderStartError(traderName, loadErr))
 			return
 		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "Failed to load trader, please check AI model, exchange and strategy configuration"})
+		SafeBadRequest(c, describeTraderStartError(traderName, err))
 		return
 	}
 

--- a/api/handler_trader_status.go
+++ b/api/handler_trader_status.go
@@ -58,96 +58,11 @@ func (s *Server) handleSyncBalance(c *gin.Context) {
 		return
 	}
 
-	// Create temporary trader to query balance
-	var tempTrader trader.Trader
-	var createErr error
-
-	// Use ExchangeType (e.g., "binance") instead of ExchangeID (which is now UUID)
-	// Convert EncryptedString fields to string
-	switch exchangeCfg.ExchangeType {
-	case "binance":
-		tempTrader = binance.NewFuturesTrader(string(exchangeCfg.APIKey), string(exchangeCfg.SecretKey), userID)
-	case "hyperliquid":
-		tempTrader, createErr = hyperliquidtrader.NewHyperliquidTrader(
-			string(exchangeCfg.APIKey),
-			exchangeCfg.HyperliquidWalletAddr,
-			exchangeCfg.Testnet,
-			exchangeCfg.HyperliquidUnifiedAcct,
-		)
-	case "aster":
-		tempTrader, createErr = aster.NewAsterTrader(
-			exchangeCfg.AsterUser,
-			exchangeCfg.AsterSigner,
-			string(exchangeCfg.AsterPrivateKey),
-		)
-	case "bybit":
-		tempTrader = bybit.NewBybitTrader(
-			string(exchangeCfg.APIKey),
-			string(exchangeCfg.SecretKey),
-		)
-	case "okx":
-		tempTrader = okx.NewOKXTrader(
-			string(exchangeCfg.APIKey),
-			string(exchangeCfg.SecretKey),
-			string(exchangeCfg.Passphrase),
-		)
-	case "bitget":
-		tempTrader = bitget.NewBitgetTrader(
-			string(exchangeCfg.APIKey),
-			string(exchangeCfg.SecretKey),
-			string(exchangeCfg.Passphrase),
-		)
-	case "gate":
-		tempTrader = gate.NewGateTrader(
-			string(exchangeCfg.APIKey),
-			string(exchangeCfg.SecretKey),
-		)
-	case "kucoin":
-		tempTrader = kucoin.NewKuCoinTrader(
-			string(exchangeCfg.APIKey),
-			string(exchangeCfg.SecretKey),
-			string(exchangeCfg.Passphrase),
-		)
-	case "lighter":
-		if exchangeCfg.LighterWalletAddr != "" && string(exchangeCfg.LighterAPIKeyPrivateKey) != "" {
-			// Lighter only supports mainnet
-			tempTrader, createErr = lighter.NewLighterTraderV2(
-				exchangeCfg.LighterWalletAddr,
-				string(exchangeCfg.LighterAPIKeyPrivateKey),
-				exchangeCfg.LighterAPIKeyIndex,
-				false, // Always use mainnet for Lighter
-			)
-		} else {
-			createErr = fmt.Errorf("Lighter requires wallet address and API Key private key")
-		}
-	default:
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Unsupported exchange type"})
-		return
-	}
-
-	if createErr != nil {
-		logger.Infof("⚠️ Failed to create temporary trader: %v", createErr)
-		SafeInternalError(c, "Failed to connect to exchange", createErr)
-		return
-	}
-
-	// Query actual balance
-	balanceInfo, balanceErr := tempTrader.GetBalance()
+	actualBalance, balanceErr := queryExchangeEquity(exchangeCfg, userID)
 	if balanceErr != nil {
 		logger.Infof("⚠️ Failed to query exchange balance: %v", balanceErr)
 		SafeInternalError(c, "Failed to query balance", balanceErr)
 		return
-	}
-
-	// Extract total equity (for P&L calculation, we need total account value, not available balance)
-	var actualBalance float64
-	// Priority: total_equity > totalWalletBalance > wallet_balance > totalEq > balance
-	balanceKeys := []string{"total_equity", "totalWalletBalance", "wallet_balance", "totalEq", "balance"}
-	for _, key := range balanceKeys {
-		if balance, ok := balanceInfo[key].(float64); ok && balance > 0 {
-			actualBalance = balance
-			break
-		}
 	}
 	if actualBalance <= 0 {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to get total equity"})

--- a/api/server.go
+++ b/api/server.go
@@ -197,6 +197,9 @@ Defaults when custom fields empty: openai→api.openai.com/v1, deepseek→api.de
 				`Returns: [{"id":"<EXACT id — use this as exchange_id when creating/updating a trader>","exchange_type":"<e.g. okx, binance>","account_name":"<user label>","enabled":<bool>}]
 CRITICAL: Always use the "id" field for exchange_id. Do not use "exchange_type" as an id.`,
 				s.handleGetExchangeConfigs)
+			s.routeWithSchema(protected, "GET", "/exchanges/:id/balance", "Get current balance for a specific exchange account",
+				`:id = EXACT id from GET /api/exchanges. Returns the live balance for the selected exchange account.`,
+				s.handleGetExchangeBalance)
 			s.routeWithSchema(protected, "POST", "/exchanges", "Create a new exchange account",
 				`Body: {"exchange_type":"<string>","account_name":"<string, user label>","enabled":true,"api_key":"<string>","secret_key":"<string>","passphrase":"<string, required for okx/gate/kucoin>"}
 exchange_type values: "binance","bybit","okx","bitget","gate","kucoin","indodax" (CEX) | "hyperliquid","aster","lighter" (DEX)

--- a/web/src/components/trader/AITradersPage.tsx
+++ b/web/src/components/trader/AITradersPage.tsx
@@ -20,6 +20,7 @@ import { ConfigStatusGrid } from './ConfigStatusGrid'
 import { TradersList } from './TradersList'
 import { BeginnerGuideCards } from './BeginnerGuideCards'
 import {
+  AlertTriangle,
   Bot,
   Plus,
   MessageCircle,
@@ -58,6 +59,140 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
   const [quickSetupLoading, setQuickSetupLoading] = useState(false)
   const [beginnerWalletAddress, setBeginnerWalletAddress] = useState<string | null>(() => getBeginnerWalletAddress())
   const isBeginnerMode = getUserMode() === 'beginner'
+  const getErrorMessage = (error: unknown, fallback: string) => {
+    if (error instanceof Error && error.message.trim() !== '') {
+      return error.message
+    }
+    return fallback
+  }
+  const localizeActionableDescription = (message: string) => {
+    let localized = message.trim()
+
+    if (language === 'zh') {
+      return localized
+    }
+
+    const replacements: Array<[RegExp, string]> = [
+      [/这次未能启动机器人：/g, 'Unable to start trader: '],
+      [/这次未能创建机器人：/g, 'Unable to create trader: '],
+      [/这次未能更新机器人：/g, 'Unable to update trader: '],
+      [/机器人「([^」]+)」暂时还不能启动，原因是：/g, 'Trader "$1" cannot be started yet because '],
+      [/机器人「([^」]+)」暂时还不能启动/g, 'Trader "$1" cannot be started yet'],
+      [/机器人「([^」]+)」已经保存，但当前暂时还不能启动，原因是：/g, 'Trader "$1" was saved, but it cannot be started yet because '],
+      [/机器人「([^」]+)」已经保存，但当前暂时还不能启动/g, 'Trader "$1" was saved, but it cannot be started yet'],
+      [/系统暂时无法从交易所读取账户余额/g, 'the system could not read the exchange account balance'],
+      [/系统暂时无法连接交易所服务/g, 'the system could not reach the exchange service'],
+      [/当前策略配置内容已损坏，系统暂时无法解析/g, 'the current strategy configuration is corrupted and cannot be parsed'],
+      [/当前机器人缺少有效的交易策略配置/g, 'this trader does not have a valid strategy configuration'],
+      [/私钥格式不正确，系统无法识别/g, 'the private key format is invalid'],
+      [/当前交易所类型暂不支持机器人初始化/g, 'this exchange type is not supported for trader initialization'],
+      [/当前交易所类型暂不支持机器人初始化/g, 'this exchange type is not supported for trader initialization'],
+      [/当前交易所账户初始化失败，请确认钱包地址和 API Key 是否匹配/g, 'the exchange account failed initialization. Please verify the wallet address and API key match'],
+      [/这个机器人关联的 AI 模型不存在/g, `this trader's AI model no longer exists`],
+      [/这个机器人关联的交易所账户不存在/g, `this trader's exchange account no longer exists`],
+      [/请检查模型、策略和交易所配置后，再重新点击启动。?/g, 'Please check the model, strategy, and exchange configuration, then try starting again.'],
+      [/请检查模型、策略和交易所配置是否完整，然后再试一次。?/g, 'Please check the model, strategy, and exchange configuration, then try again.'],
+      [/请前往「设置 > 模型配置」检查后，再重新点击启动。?/g, 'Go to Settings > Model Config, verify it, then try starting again.'],
+      [/请前往「设置 > 交易所配置」检查后，再重新点击启动。?/g, 'Go to Settings > Exchange Config, verify it, then try starting again.'],
+      [/请先为这个钱包充值，再重新点击启动。?/g, 'Please top up this wallet before starting again.'],
+    ]
+
+    for (const [pattern, replacement] of replacements) {
+      localized = localized.replace(pattern, replacement)
+    }
+
+    localized = localized
+      .replace(/。/g, '.')
+      .replace(/，/g, ', ')
+      .replace(/\s+/g, ' ')
+      .trim()
+
+    return localized
+  }
+  const normalizeActionableDescription = (message: string, title: string) => {
+    const prefixes = [
+      '这次未能创建机器人：',
+      '机器人创建失败：',
+      '这次未能更新机器人：',
+      '机器人更新失败：',
+      '这次未能启动机器人：',
+      'Failed to create trader:',
+      'Failed to update trader:',
+      'Unable to create trader:',
+      'Unable to update trader:',
+      'Unable to start trader:',
+    ]
+
+    let description = localizeActionableDescription(message)
+    if (description === title) return ''
+
+    for (const prefix of prefixes) {
+      if (description.startsWith(prefix)) {
+        description = description.slice(prefix.length).trim()
+        break
+      }
+    }
+
+    return description
+  }
+  const showActionableError = (title: string, error: unknown) => {
+    const message = getErrorMessage(error, title)
+    const description = normalizeActionableDescription(message, title)
+
+    if (description === '') {
+      toast.error(title)
+      return
+    }
+
+    toast.error(title, {
+      description,
+    })
+  }
+  const parseBalanceUsdc = (balance?: string) => {
+    if (!balance) return null
+    const parsed = Number.parseFloat(balance)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  const getClaw402BalanceMessage = (balance: number, blocking: boolean) => {
+    if (language === 'zh') {
+      return blocking
+        ? `当前 Claw402 钱包余额为 ${balance.toFixed(6)} USDC，AI 调用无法执行。请先为这个钱包充值，再重新点击启动。`
+        : `当前 Claw402 钱包余额仅剩 ${balance.toFixed(6)} USDC，虽然还能尝试启动，但很快可能因为 AI 调用费用不足而停止。建议先补一点 USDC。`
+    }
+
+    return blocking
+      ? `Your Claw402 wallet balance is ${balance.toFixed(6)} USDC. AI calls cannot run with zero balance. Please top up this wallet before starting again.`
+      : `Your Claw402 wallet balance is only ${balance.toFixed(6)} USDC. You can still try to start, but AI calls may stop soon due to insufficient funds.`
+  }
+  const getClaw402BalanceIssue = (traderId: string) => {
+    const trader = traders?.find((item) => item.trader_id === traderId)
+    if (!trader) return null
+
+    const model =
+      allModels.find((item) => item.id === trader.ai_model) ||
+      allModels.find((item) => item.provider === trader.ai_model)
+
+    if (!model || model.provider !== 'claw402') return null
+
+    const balance = parseBalanceUsdc(model.balanceUsdc)
+    if (balance === null) return null
+    if (balance <= 0) {
+      return {
+        blocking: true,
+        title: language === 'zh' ? '启动失败' : 'Start failed',
+        description: getClaw402BalanceMessage(balance, true),
+      }
+    }
+    if (balance < 1) {
+      return {
+        blocking: false,
+        title: language === 'zh' ? 'Claw402 余额偏低' : 'Low Claw402 balance',
+        description: getClaw402BalanceMessage(balance, false),
+      }
+    }
+
+    return null
+  }
 
   const navigateInApp = (path: string) => {
     navigate(path)
@@ -167,6 +302,23 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
     }) || []
 
   const enabledModels = allModels?.filter((m) => m.enabled) || []
+  const enabledClaw402Model = enabledModels.find((model) => model.provider === 'claw402') || null
+  const enabledClaw402Balance = parseBalanceUsdc(enabledClaw402Model?.balanceUsdc)
+  const claw402BalanceAlert =
+    enabledClaw402Model && enabledClaw402Balance !== null && enabledClaw402Balance < 1
+      ? {
+          blocking: enabledClaw402Balance <= 0,
+          title:
+            language === 'zh'
+              ? enabledClaw402Balance <= 0
+                ? 'Claw402 钱包余额为 0'
+                : 'Claw402 钱包余额偏低'
+              : enabledClaw402Balance <= 0
+                ? 'Claw402 wallet balance is zero'
+                : 'Claw402 wallet balance is low',
+          description: getClaw402BalanceMessage(enabledClaw402Balance, enabledClaw402Balance <= 0),
+        }
+      : null
   const enabledExchanges =
     allExchanges?.filter((e) => {
       if (!e.enabled) return false
@@ -224,26 +376,19 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
 
   const handleCreateTrader = async (data: CreateTraderRequest) => {
     try {
-      const model = allModels?.find((m) => m.id === data.ai_model_id)
-      const exchange = allExchanges?.find((e) => e.id === data.exchange_id)
-
-      if (!model?.enabled) {
-        toast.error(t('modelNotConfigured', language))
-        return
+      const createdTrader = await api.createTrader(data)
+      if (createdTrader.startup_warning) {
+        toast.success(t('aiTradersToast.created', language), {
+          description: createdTrader.startup_warning,
+        })
+      } else {
+        toast.success(t('aiTradersToast.created', language))
       }
-
-      if (!exchange?.enabled) {
-        toast.error(t('exchangeNotConfigured', language))
-        return
-      }
-
-      await api.createTrader(data)
-      toast.success(t('aiTradersToast.created', language))
       setShowCreateModal(false)
       await mutateTraders()
     } catch (error) {
       console.error('Failed to create trader:', error)
-      toast.error(t('createTraderFailed', language))
+      showActionableError(t('createTraderFailed', language), error)
     }
   }
 
@@ -293,7 +438,7 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
       await mutateTraders()
     } catch (error) {
       console.error('Failed to update trader:', error)
-      toast.error(t('updateTraderFailed', language))
+      showActionableError(t('updateTraderFailed', language), error)
     }
   }
 
@@ -318,16 +463,31 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
     try {
       if (running) {
         await api.stopTrader(traderId)
-      toast.success(t('aiTradersToast.stopped', language))
+        toast.success(t('aiTradersToast.stopped', language))
       } else {
+        const claw402Issue = getClaw402BalanceIssue(traderId)
+        if (claw402Issue?.blocking) {
+          toast.error(claw402Issue.title, {
+            description: claw402Issue.description,
+          })
+          return
+        }
+        if (claw402Issue && !claw402Issue.blocking) {
+          toast.warning(claw402Issue.title, {
+            description: claw402Issue.description,
+          })
+        }
         await api.startTrader(traderId)
-      toast.success(t('aiTradersToast.started', language))
+        toast.success(t('aiTradersToast.started', language))
       }
 
       await mutateTraders()
     } catch (error) {
       console.error('Failed to toggle trader:', error)
-      toast.error(t('operationFailed', language))
+      showActionableError(
+        running ? t('aiTradersToast.stopFailed', language) : t('aiTradersToast.startFailed', language),
+        error
+      )
     }
   }
 
@@ -751,6 +911,52 @@ export function AITradersPage({ onTraderSelect }: AITradersPageProps) {
             onOpenStrategy={() => navigateInApp('/strategy')}
             onCreateTrader={() => setShowCreateModal(true)}
           />
+        ) : null}
+
+        {claw402BalanceAlert ? (
+          <div
+            className="mb-6 rounded-xl border px-4 py-4 md:px-5 md:py-4 flex flex-col md:flex-row md:items-start md:justify-between gap-3"
+            style={{
+              borderColor: claw402BalanceAlert.blocking ? 'rgba(239, 68, 68, 0.55)' : 'rgba(245, 158, 11, 0.45)',
+              background: claw402BalanceAlert.blocking ? 'rgba(127, 29, 29, 0.22)' : 'rgba(120, 53, 15, 0.18)',
+            }}
+          >
+            <div className="flex items-start gap-3">
+              <div
+                className="mt-0.5 rounded-full p-2"
+                style={{
+                  background: claw402BalanceAlert.blocking ? 'rgba(239, 68, 68, 0.16)' : 'rgba(245, 158, 11, 0.14)',
+                  color: claw402BalanceAlert.blocking ? '#F87171' : '#FBBF24',
+                }}
+              >
+                <AlertTriangle className="w-4 h-4" />
+              </div>
+              <div>
+                <div
+                  className="text-sm font-semibold"
+                  style={{ color: claw402BalanceAlert.blocking ? '#FCA5A5' : '#FDE68A' }}
+                >
+                  {claw402BalanceAlert.title}
+                </div>
+                <div className="text-sm mt-1 leading-6" style={{ color: '#D4D4D8' }}>
+                  {claw402BalanceAlert.description}
+                </div>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => enabledClaw402Model && handleModelClick(enabledClaw402Model.id)}
+              className="px-4 py-2 rounded text-xs font-mono uppercase tracking-wider border whitespace-nowrap self-start"
+              style={{
+                borderColor: claw402BalanceAlert.blocking ? 'rgba(248, 113, 113, 0.45)' : 'rgba(251, 191, 36, 0.35)',
+                color: claw402BalanceAlert.blocking ? '#FCA5A5' : '#FDE68A',
+                background: 'rgba(0, 0, 0, 0.18)',
+              }}
+            >
+              {language === 'zh' ? '查看 AI 钱包' : 'Open AI wallet'}
+            </button>
+          </div>
         ) : null}
 
         {/* Configuration Status Grid */}

--- a/web/src/components/trader/TraderConfigModal.tsx
+++ b/web/src/components/trader/TraderConfigModal.tsx
@@ -124,9 +124,33 @@ export function TraderConfigModal({
     setFormData((prev) => ({ ...prev, [field]: value }))
   }
 
+  const handleExchangeChange = (exchangeId: string) => {
+    setBalanceFetchError('')
+    setFormData((prev) => {
+      if (prev.exchange_id === exchangeId) {
+        return prev
+      }
+
+      const next: FormState = { ...prev, exchange_id: exchangeId }
+
+      // Exchange balance belongs to the selected exchange, not the trader record.
+      // Clear the old baseline so we don't carry Exchange B's balance into Exchange A.
+      if (isEditMode) {
+        next.initial_balance = undefined
+      }
+
+      return next
+    })
+  }
+
   const handleFetchCurrentBalance = async () => {
-    if (!isEditMode || !traderData?.trader_id) {
+    if (!isEditMode) {
        setBalanceFetchError(t('fetchBalanceEditModeOnly', language))
+      return
+    }
+
+    if (!formData.exchange_id) {
+      setBalanceFetchError(t('balanceFetchFailed', language))
       return
     }
 
@@ -135,21 +159,23 @@ export function TraderConfigModal({
 
     try {
       const result = await httpClient.get<{
-        total_equity?: number
         balance?: number
-      }>(`/api/account?trader_id=${traderData.trader_id}`)
+      }>(`/api/exchanges/${formData.exchange_id}/balance`)
 
       if (result.success && result.data) {
-        const currentBalance =
-          result.data.total_equity || result.data.balance || 0
+        const currentBalance = result.data.balance || 0
         setFormData((prev) => ({ ...prev, initial_balance: currentBalance }))
         toast.success(t('balanceFetched', language))
       } else {
-        throw new Error(result.message || t('balanceFetchFailed', language))
+        setBalanceFetchError(result.message || t('balanceFetchFailed', language))
       }
     } catch (error) {
       console.error(t('balanceFetchFailed', language) + ':', error)
-       setBalanceFetchError(t('balanceFetchNetworkError', language))
+      setBalanceFetchError(
+        error instanceof Error && error.message
+          ? error.message
+          : t('balanceFetchNetworkError', language)
+      )
     } finally {
       setIsFetchingBalance(false)
     }
@@ -176,8 +202,6 @@ export function TraderConfigModal({
       }
 
       await onSave(saveData)
-      toast.success(t('saveSuccess', language))
-      onClose()
     } catch (error) {
        console.error(t('saveFailed', language) + ':', error)
     } finally {
@@ -269,9 +293,7 @@ export function TraderConfigModal({
                   </label>
                   <NofxSelect
                     value={formData.exchange_id}
-                    onChange={(val) =>
-                      handleInputChange('exchange_id', val)
-                    }
+                    onChange={handleExchangeChange}
                     className="w-full px-3 py-2 bg-[#0B0E11] border border-[#2B3139] rounded text-[#EAECEF]"
                     options={availableExchanges.map((exchange) => ({
                       value: exchange.id,

--- a/web/src/lib/api/traders.ts
+++ b/web/src/lib/api/traders.ts
@@ -23,7 +23,9 @@ export const traderApi = {
       `${API_BASE}/traders`,
       request
     )
-    if (!result.success) throw new Error('Failed to create trader')
+    if (!result.success) {
+      throw new Error(result.message || 'Failed to create trader')
+    }
     return result.data!
   },
 
@@ -36,7 +38,9 @@ export const traderApi = {
     const result = await httpClient.post(
       `${API_BASE}/traders/${traderId}/start`
     )
-    if (!result.success) throw new Error('Failed to start trader')
+    if (!result.success) {
+      throw new Error(result.message || 'Failed to start trader')
+    }
   },
 
   async stopTrader(traderId: string): Promise<void> {
@@ -88,7 +92,9 @@ export const traderApi = {
       `${API_BASE}/traders/${traderId}`,
       request
     )
-    if (!result.success) throw new Error('Failed to update trader')
+    if (!result.success) {
+      throw new Error(result.message || 'Failed to update trader')
+    }
     return result.data!
   },
 }

--- a/web/src/lib/httpClient.ts
+++ b/web/src/lib/httpClient.ts
@@ -86,6 +86,8 @@ export class HttpClient {
    */
   private async handleError(error: AxiosError): Promise<any> {
     const isSilent = (error.config as any)?.silentError === true
+    const errorData = error.response?.data as { error?: string; message?: string } | undefined
+    const serverMessage = errorData?.error || errorData?.message
 
     // Network error (no response from server)
     if (!error.response) {
@@ -98,10 +100,7 @@ export class HttpClient {
       throw new Error('Network error')
     }
 
-    const { status } = error.response as AxiosResponse<{
-      error?: string
-      message?: string
-    }>
+    const status = error.response?.status ?? 0
 
     // Handle 401 Unauthorized
     if (status === 401) {
@@ -159,6 +158,9 @@ export class HttpClient {
 
     // Handle 500+ Server Error - system error
     if (status >= 500) {
+      if (serverMessage) {
+        return Promise.reject(error)
+      }
       if (!isSilent) {
         toast.error('Server Error', {
           id: 'server-error',

--- a/web/src/types/trading.ts
+++ b/web/src/types/trading.ts
@@ -97,6 +97,7 @@ export interface TraderInfo {
   ai_model: string
   exchange_id?: string
   is_running?: boolean
+  startup_warning?: string
   show_in_competition?: boolean
   strategy_id?: string
   strategy_name?: string


### PR DESCRIPTION
## Summary

- Problem:
  Trader creation and startup failures were hard to understand in the UI. Error toasts often collapsed into generic messages like `Server Error` or `Operation failed`, and users could not tell whether the issue came from the AI model, exchange config, missing balance, or startup validation. In addition, trader editing could reuse a stale `initial_balance` when switching exchanges, which made a trader look startable even after moving it back to an exchange account without funds. The Claw402 wallet state was also too easy to miss, so users could try to start traders without clearly seeing that the AI wallet balance was low or empty.
- What changed:
  Improved trader create/start/update error reporting end-to-end so the frontend shows actionable reasons instead of generic failures. Added clearer startup validation messages, cleaned up misleading success/error flows in trader modals and toasts, and preserved failed-start context for the user instead of hiding it behind generic system errors. Fixed stale trader balance baseline handling when switching exchanges so old exchange balance is not reused on a different exchange. Added clearer Claw402 wallet low-balance / zero-balance warnings in the trader page and startup flow so users are warned earlier before AI calls fail.
- What did NOT change (scope boundary):
  No trading strategy logic, no exchange execution logic, no database schema, and no env/config format were changed. This PR does not redesign the onboarding flow or add new exchange providers.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactoring
- [ ] Docs
- [ ] Security fix
- [ ] Chore / infra

## Scope

- [x] API / server
- [x] Web UI / frontend
- [ ] Trading engine / strategies
- [ ] MCP / AI clients
- [ ] Telegram bot / agent
- [ ] Config / deployment
- [ ] CI/CD / infra

## Linked Issues

- Closes #
- Related #

## Testing

What you verified and how:

- [x] `go build ./...` passes
- [ ] `go test ./...` passes
- [x] Manual testing done (describe below)

Manual verification:

- Verified frontend build passes with `npm run build`
- Verified backend build passes with `go build ./...`
- Rebuilt local containers and confirmed the app is healthy on `localhost:3000` and `localhost:8080`
- Tested trader create/start failure flows and confirmed the UI now shows actionable error reasons instead of generic server errors
- Tested Claw402 low-balance / zero-balance warning behavior in the trader page and startup flow
- Tested trader edit flow when switching exchanges and confirmed stale `initial_balance` is no longer silently reused across different exchange accounts

## Security Impact

- Secrets/keys handling changed? (`No`)
- New/changed API endpoints? (`Yes`)
- User input validation affected? (`Yes`)

## Compatibility

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, upgrade steps:
