### PR TITLE
fix(trader): honor OKX margin mode and explicitly route nofx data via claw402 wallet

### DIFF
--- a/api/strategy.go
+++ b/api/strategy.go
@@ -516,8 +516,31 @@ func (s *Server) handleStrategyTestRun(c *gin.Context) {
 		req.PromptVariant = "balanced"
 	}
 
+	claw402WalletKey := ""
+	if req.AIModelID != "" {
+		model, err := s.store.AIModel().Get(userID, req.AIModelID)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":       "Failed to load selected AI model",
+				"ai_response": "",
+			})
+			return
+		}
+
+		if model.Provider == "claw402" {
+			claw402WalletKey = string(model.APIKey)
+			if claw402WalletKey == "" {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error":       "Selected claw402 model is missing wallet private key",
+					"ai_response": "",
+				})
+				return
+			}
+		}
+	}
+
 	// Create strategy engine to build prompt
-	engine := kernel.NewStrategyEngine(&req.Config)
+	engine := kernel.NewStrategyEngine(&req.Config, claw402WalletKey)
 
 	// Get candidate coins
 	candidates, err := engine.GetCandidateCoins()

--- a/api/strategy.go
+++ b/api/strategy.go
@@ -516,27 +516,13 @@ func (s *Server) handleStrategyTestRun(c *gin.Context) {
 		req.PromptVariant = "balanced"
 	}
 
-	claw402WalletKey := ""
-	if req.AIModelID != "" {
-		model, err := s.store.AIModel().Get(userID, req.AIModelID)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":       "Failed to load selected AI model",
-				"ai_response": "",
-			})
-			return
-		}
-
-		if model.Provider == "claw402" {
-			claw402WalletKey = string(model.APIKey)
-			if claw402WalletKey == "" {
-				c.JSON(http.StatusBadRequest, gin.H{
-					"error":       "Selected claw402 model is missing wallet private key",
-					"ai_response": "",
-				})
-				return
-			}
-		}
+	claw402WalletKey, err := s.resolveStrategyDataWalletKey(userID, req.AIModelID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":       err.Error(),
+			"ai_response": "",
+		})
+		return
 	}
 
 	// Create strategy engine to build prompt
@@ -719,4 +705,39 @@ func (s *Server) runRealAITest(userID, modelID, systemPrompt, userPrompt string)
 	}
 
 	return response, nil
+}
+
+func (s *Server) resolveStrategyDataWalletKey(userID, selectedModelID string) (string, error) {
+	if selectedModelID != "" {
+		model, err := s.store.AIModel().Get(userID, selectedModelID)
+		if err != nil {
+			return "", fmt.Errorf("failed to load selected AI model")
+		}
+
+		if model.Provider == "claw402" {
+			walletKey := string(model.APIKey)
+			if walletKey == "" {
+				return "", fmt.Errorf("selected claw402 model is missing wallet private key")
+			}
+			return walletKey, nil
+		}
+	}
+
+	models, err := s.store.AIModel().List(userID)
+	if err != nil {
+		return "", fmt.Errorf("failed to load AI models")
+	}
+
+	for _, model := range models {
+		if model == nil || model.Provider != "claw402" {
+			continue
+		}
+
+		walletKey := string(model.APIKey)
+		if walletKey != "" {
+			return walletKey, nil
+		}
+	}
+
+	return "", nil
 }

--- a/manager/trader_manager.go
+++ b/manager/trader_manager.go
@@ -703,6 +703,8 @@ func (tm *TraderManager) addTraderFromStore(traderCfg *store.Trader, aiModelCfg 
 		traderConfig.CustomAPIKey = string(aiModelCfg.APIKey)
 	}
 
+	traderConfig.Claw402WalletKey = resolveTraderDataWalletKey(st, traderCfg.UserID, aiModelCfg)
+
 	// Create trader instance
 	at, err := trader.NewAutoTrader(traderConfig, st, traderCfg.UserID)
 	if err != nil {
@@ -741,3 +743,31 @@ func (tm *TraderManager) addTraderFromStore(traderCfg *store.Trader, aiModelCfg 
 	return nil
 }
 
+func resolveTraderDataWalletKey(st *store.Store, userID string, selectedModel *store.AIModel) string {
+	if selectedModel != nil && selectedModel.Provider == "claw402" {
+		if walletKey := string(selectedModel.APIKey); walletKey != "" {
+			return walletKey
+		}
+	}
+
+	if st == nil {
+		return ""
+	}
+
+	models, err := st.AIModel().List(userID)
+	if err != nil {
+		logger.Warnf("⚠️ Failed to load claw402 wallet for trader data routing: %v", err)
+		return ""
+	}
+
+	for _, model := range models {
+		if model == nil || model.Provider != "claw402" {
+			continue
+		}
+		if walletKey := string(model.APIKey); walletKey != "" {
+			return walletKey
+		}
+	}
+
+	return ""
+}

--- a/trader/auto_trader.go
+++ b/trader/auto_trader.go
@@ -2,14 +2,13 @@ package trader
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/crypto"
 	"nofx/kernel"
 	"nofx/logger"
 	"nofx/mcp"
 	_ "nofx/mcp/payment"
 	_ "nofx/mcp/provider"
 	"nofx/store"
-	"nofx/wallet"
-	"github.com/ethereum/go-ethereum/crypto"
 	"nofx/trader/aster"
 	"nofx/trader/binance"
 	"nofx/trader/bitget"
@@ -20,6 +19,7 @@ import (
 	"nofx/trader/kucoin"
 	"nofx/trader/lighter"
 	"nofx/trader/okx"
+	"nofx/wallet"
 	"sync"
 	"time"
 )
@@ -90,9 +90,10 @@ type AutoTraderConfig struct {
 	QwenKey     string
 
 	// Custom AI API configuration
-	CustomAPIURL    string
-	CustomAPIKey    string
-	CustomModelName string
+	CustomAPIURL     string
+	CustomAPIKey     string
+	CustomModelName  string
+	Claw402WalletKey string
 
 	// Scan configuration
 	ScanInterval time.Duration // Scan interval (recommended 3 minutes)
@@ -148,9 +149,9 @@ type AutoTrader struct {
 	userID                string             // User ID
 	gridState             *GridState         // Grid trading state (only used when StrategyType == "grid_trading")
 	claw402WalletAddr     string             // Claw402 wallet address (derived from private key at start)
-	consecutiveAIFailures int               // Consecutive AI call failures
-	safeMode              bool              // Safe mode: no new positions, protect existing ones
-	safeModeReason        string            // Why safe mode was activated
+	consecutiveAIFailures int                // Consecutive AI call failures
+	safeMode              bool               // Safe mode: no new positions, protect existing ones
+	safeModeReason        string             // Why safe mode was activated
 }
 
 // NewAutoTrader creates an automatic trader
@@ -335,8 +336,8 @@ func NewAutoTrader(config AutoTraderConfig, st *store.Store, userID string) (*Au
 	}
 	// Pass claw402 wallet key to strategy engine so nofxos data requests
 	// are routed through claw402 (reuses the same wallet as AI calls)
-	var claw402Key string
-	if config.AIModel == "claw402" && config.CustomAPIKey != "" {
+	claw402Key := config.Claw402WalletKey
+	if claw402Key == "" && config.AIModel == "claw402" && config.CustomAPIKey != "" {
 		claw402Key = config.CustomAPIKey
 	}
 	strategyEngine := kernel.NewStrategyEngine(config.StrategyConfig, claw402Key)

--- a/trader/auto_trader_grid.go
+++ b/trader/auto_trader_grid.go
@@ -324,6 +324,17 @@ func (at *AutoTrader) InitializeGrid() error {
 
 	at.gridState.IsInitialized = true
 
+	// Keep grid orders aligned with the trader's configured cross/isolated mode.
+	if err := at.trader.SetMarginMode(gridConfig.Symbol, at.config.IsCrossMargin); err != nil {
+		logger.Warnf("[Grid] Failed to set margin mode for %s: %v", gridConfig.Symbol, err)
+	} else {
+		marginMode := "cross"
+		if !at.config.IsCrossMargin {
+			marginMode = "isolated"
+		}
+		logger.Infof("[Grid] Margin mode set to %s for %s", marginMode, gridConfig.Symbol)
+	}
+
 	// CRITICAL: Set leverage on exchange before trading
 	if err := at.trader.SetLeverage(gridConfig.Symbol, gridConfig.Leverage); err != nil {
 		logger.Warnf("[Grid] Failed to set leverage %dx on exchange: %v", gridConfig.Leverage, err)

--- a/trader/okx/trader.go
+++ b/trader/okx/trader.go
@@ -41,7 +41,7 @@ type OKXTrader struct {
 	secretKey  string
 	passphrase string
 
-	// Margin mode setting
+	// Margin mode setting used for new orders and leverage changes.
 	isCrossMargin bool
 
 	// Position mode: "long_short_mode" (hedge) or "net_mode" (one-way)
@@ -121,6 +121,7 @@ func NewOKXTrader(apiKey, secretKey, passphrase string) *OKXTrader {
 		apiKey:           apiKey,
 		secretKey:        secretKey,
 		passphrase:       passphrase,
+		isCrossMargin:    true,
 		httpClient:       httpClient,
 		cacheDuration:    15 * time.Second,
 		instrumentsCache: make(map[string]*OKXInstrument),
@@ -139,8 +140,16 @@ func NewOKXTrader(apiKey, secretKey, passphrase string) *OKXTrader {
 		}
 	}
 
-	logger.Infof("✓ OKX trader initialized with position mode: %s", trader.positionMode)
+	logger.Infof("✓ OKX trader initialized with position mode: %s, default margin mode: %s",
+		trader.positionMode, trader.marginMode())
 	return trader
+}
+
+func (t *OKXTrader) marginMode() string {
+	if t.isCrossMargin {
+		return "cross"
+	}
+	return "isolated"
 }
 
 // detectPositionMode gets current position mode from account config

--- a/trader/okx/trader_account.go
+++ b/trader/okx/trader_account.go
@@ -82,31 +82,14 @@ func (t *OKXTrader) GetBalance() (map[string]interface{}, error) {
 
 // SetMarginMode sets margin mode
 func (t *OKXTrader) SetMarginMode(symbol string, isCrossMargin bool) error {
-	instId := t.convertSymbol(symbol)
 	t.isCrossMargin = isCrossMargin
 	mgnMode := t.marginMode()
 
-	body := map[string]interface{}{
-		"instId":  instId,
-		"mgnMode": mgnMode,
-	}
-
-	_, err := t.doRequest("POST", "/api/v5/account/set-isolated-mode", body)
-	if err != nil {
-		// Ignore error if already in target mode
-		if strings.Contains(err.Error(), "already") {
-			logger.Infof("  ✓ %s margin mode is already %s", symbol, mgnMode)
-			return nil
-		}
-		// Cannot change when there are positions
-		if strings.Contains(err.Error(), "position") {
-			logger.Infof("  ⚠️ %s has positions, cannot change margin mode", symbol)
-			return nil
-		}
-		return err
-	}
-
-	logger.Infof("  ✓ %s margin mode set to %s", symbol, mgnMode)
+	// OKX V5 unified account applies cross/isolated per order via tdMode,
+	// while leverage uses mgnMode on /account/set-leverage.
+	// Persist the configured mode locally so subsequent leverage/order calls use it,
+	// instead of calling the legacy isolated-mode endpoint that returns 51000 errors.
+	logger.Infof("  ✓ %s margin mode configured as %s (applied via tdMode/mgnMode on subsequent requests)", symbol, mgnMode)
 	return nil
 }
 

--- a/trader/okx/trader_account.go
+++ b/trader/okx/trader_account.go
@@ -83,11 +83,8 @@ func (t *OKXTrader) GetBalance() (map[string]interface{}, error) {
 // SetMarginMode sets margin mode
 func (t *OKXTrader) SetMarginMode(symbol string, isCrossMargin bool) error {
 	instId := t.convertSymbol(symbol)
-
-	mgnMode := "isolated"
-	if isCrossMargin {
-		mgnMode = "cross"
-	}
+	t.isCrossMargin = isCrossMargin
+	mgnMode := t.marginMode()
 
 	body := map[string]interface{}{
 		"instId":  instId,
@@ -116,13 +113,14 @@ func (t *OKXTrader) SetMarginMode(symbol string, isCrossMargin bool) error {
 // SetLeverage sets leverage
 func (t *OKXTrader) SetLeverage(symbol string, leverage int) error {
 	instId := t.convertSymbol(symbol)
+	marginMode := t.marginMode()
 
 	// Set leverage for both long and short
 	for _, posSide := range []string{"long", "short"} {
 		body := map[string]interface{}{
 			"instId":  instId,
 			"lever":   strconv.Itoa(leverage),
-			"mgnMode": "cross",
+			"mgnMode": marginMode,
 			"posSide": posSide,
 		}
 
@@ -136,7 +134,7 @@ func (t *OKXTrader) SetLeverage(symbol string, leverage int) error {
 		}
 	}
 
-	logger.Infof("  ✓ %s leverage set to %dx", symbol, leverage)
+	logger.Infof("  ✓ %s leverage set to %dx (%s)", symbol, leverage, marginMode)
 	return nil
 }
 

--- a/trader/okx/trader_margin_mode_test.go
+++ b/trader/okx/trader_margin_mode_test.go
@@ -1,0 +1,162 @@
+package okx
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"nofx/trader/types"
+)
+
+type capturedRequest struct {
+	Method string
+	Path   string
+	Body   map[string]interface{}
+}
+
+type recordingTransport struct {
+	requests []capturedRequest
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body map[string]interface{}
+	if req.Body != nil {
+		data, _ := io.ReadAll(req.Body)
+		if len(data) > 0 && strings.HasPrefix(strings.TrimSpace(string(data)), "{") {
+			_ = json.Unmarshal(data, &body)
+		}
+	}
+
+	rt.requests = append(rt.requests, capturedRequest{
+		Method: req.Method,
+		Path:   req.URL.Path,
+		Body:   body,
+	})
+
+	response := `{"code":"0","msg":"","data":[]}`
+	switch req.URL.Path {
+	case okxInstrumentsPath:
+		response = `{"code":"0","msg":"","data":[{"instId":"BTC-USDT-SWAP","ctVal":"0.01","ctMult":"1","lotSz":"1","minSz":"1","maxMktSz":"100000","tickSz":"0.1","ctType":"linear"}]}`
+	case okxOrderPath:
+		response = `{"code":"0","msg":"","data":[{"ordId":"123","clOrdId":"abc","sCode":"0","sMsg":""}]}`
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewBufferString(response)),
+	}, nil
+}
+
+func (rt *recordingTransport) requestsForPath(path string) []capturedRequest {
+	var matches []capturedRequest
+	for _, req := range rt.requests {
+		if req.Path == path {
+			matches = append(matches, req)
+		}
+	}
+	return matches
+}
+
+func newTestOKXTrader(rt *recordingTransport, isCrossMargin bool) *OKXTrader {
+	return &OKXTrader{
+		apiKey:        "key",
+		secretKey:     "secret",
+		passphrase:    "pass",
+		isCrossMargin: isCrossMargin,
+		positionMode:  "long_short_mode",
+		httpClient: &http.Client{
+			Transport: rt,
+		},
+		cacheDuration:        15 * time.Second,
+		instrumentsCache:     make(map[string]*OKXInstrument),
+		instrumentsCacheTime: time.Now(),
+	}
+}
+
+func TestOKXSetLeverageUsesConfiguredMarginMode(t *testing.T) {
+	rt := &recordingTransport{}
+	trader := newTestOKXTrader(rt, false)
+
+	if err := trader.SetLeverage("BTCUSDT", 5); err != nil {
+		t.Fatalf("SetLeverage failed: %v", err)
+	}
+
+	leverageRequests := rt.requestsForPath(okxLeveragePath)
+	if len(leverageRequests) != 2 {
+		t.Fatalf("expected 2 leverage requests, got %d", len(leverageRequests))
+	}
+
+	for _, req := range leverageRequests {
+		if req.Body["mgnMode"] != "isolated" {
+			t.Fatalf("expected isolated leverage mode, got %#v", req.Body["mgnMode"])
+		}
+	}
+}
+
+func TestOKXOpenLongUsesConfiguredMarginMode(t *testing.T) {
+	rt := &recordingTransport{}
+	trader := newTestOKXTrader(rt, false)
+
+	if _, err := trader.OpenLong("BTCUSDT", 0.1, 5); err != nil {
+		t.Fatalf("OpenLong failed: %v", err)
+	}
+
+	orderRequests := rt.requestsForPath(okxOrderPath)
+	if len(orderRequests) == 0 {
+		t.Fatal("expected at least one order request")
+	}
+
+	lastOrder := orderRequests[len(orderRequests)-1]
+	if lastOrder.Body["tdMode"] != "isolated" {
+		t.Fatalf("expected isolated tdMode, got %#v", lastOrder.Body["tdMode"])
+	}
+}
+
+func TestOKXSetStopLossUsesConfiguredMarginMode(t *testing.T) {
+	rt := &recordingTransport{}
+	trader := newTestOKXTrader(rt, false)
+
+	if err := trader.SetStopLoss("BTCUSDT", "LONG", 0.1, 90000); err != nil {
+		t.Fatalf("SetStopLoss failed: %v", err)
+	}
+
+	algoRequests := rt.requestsForPath(okxAlgoOrderPath)
+	if len(algoRequests) != 1 {
+		t.Fatalf("expected 1 algo order request, got %d", len(algoRequests))
+	}
+
+	if algoRequests[0].Body["tdMode"] != "isolated" {
+		t.Fatalf("expected isolated tdMode, got %#v", algoRequests[0].Body["tdMode"])
+	}
+}
+
+func TestOKXPlaceLimitOrderUsesConfiguredMarginMode(t *testing.T) {
+	rt := &recordingTransport{}
+	trader := newTestOKXTrader(rt, false)
+
+	_, err := trader.PlaceLimitOrder(&types.LimitOrderRequest{
+		Symbol:       "BTCUSDT",
+		Side:         "BUY",
+		PositionSide: "LONG",
+		Price:        95000,
+		Quantity:     0.1,
+		Leverage:     3,
+	})
+	if err != nil {
+		t.Fatalf("PlaceLimitOrder failed: %v", err)
+	}
+
+	orderRequests := rt.requestsForPath(okxOrderPath)
+	if len(orderRequests) != 1 {
+		t.Fatalf("expected 1 limit order request, got %d", len(orderRequests))
+	}
+
+	if orderRequests[0].Body["tdMode"] != "isolated" {
+		t.Fatalf("expected isolated tdMode, got %#v", orderRequests[0].Body["tdMode"])
+	}
+}

--- a/trader/okx/trader_margin_mode_test.go
+++ b/trader/okx/trader_margin_mode_test.go
@@ -98,6 +98,34 @@ func TestOKXSetLeverageUsesConfiguredMarginMode(t *testing.T) {
 	}
 }
 
+func TestOKXSetMarginModeUpdatesFutureRequestsWithoutAPIError(t *testing.T) {
+	rt := &recordingTransport{}
+	trader := newTestOKXTrader(rt, true)
+
+	if err := trader.SetMarginMode("BTCUSDT", false); err != nil {
+		t.Fatalf("SetMarginMode failed: %v", err)
+	}
+
+	if len(rt.requestsForPath("/api/v5/account/set-isolated-mode")) != 0 {
+		t.Fatal("expected SetMarginMode not to call legacy isolated-mode endpoint")
+	}
+
+	if err := trader.SetLeverage("BTCUSDT", 5); err != nil {
+		t.Fatalf("SetLeverage failed: %v", err)
+	}
+
+	leverageRequests := rt.requestsForPath(okxLeveragePath)
+	if len(leverageRequests) != 2 {
+		t.Fatalf("expected 2 leverage requests, got %d", len(leverageRequests))
+	}
+
+	for _, req := range leverageRequests {
+		if req.Body["mgnMode"] != "isolated" {
+			t.Fatalf("expected isolated leverage mode after SetMarginMode(false), got %#v", req.Body["mgnMode"])
+		}
+	}
+}
+
 func TestOKXOpenLongUsesConfiguredMarginMode(t *testing.T) {
 	rt := &recordingTransport{}
 	trader := newTestOKXTrader(rt, false)

--- a/trader/okx/trader_orders.go
+++ b/trader/okx/trader_orders.go
@@ -41,9 +41,11 @@ func (t *OKXTrader) OpenLong(symbol string, quantity float64, leverage int) (map
 		szStr = t.formatSize(sz, inst)
 	}
 
+	marginMode := t.marginMode()
+
 	body := map[string]interface{}{
 		"instId":  instId,
-		"tdMode":  "cross",
+		"tdMode":  marginMode,
 		"side":    "buy",
 		"posSide": "long",
 		"ordType": "market",
@@ -118,9 +120,11 @@ func (t *OKXTrader) OpenShort(symbol string, quantity float64, leverage int) (ma
 		szStr = t.formatSize(sz, inst)
 	}
 
+	marginMode := t.marginMode()
+
 	body := map[string]interface{}{
 		"instId":  instId,
-		"tdMode":  "cross",
+		"tdMode":  marginMode,
 		"side":    "sell",
 		"posSide": "short",
 		"ordType": "market",
@@ -410,9 +414,11 @@ func (t *OKXTrader) SetStopLoss(symbol string, positionSide string, quantity, st
 		posSide = "short"
 	}
 
+	marginMode := t.marginMode()
+
 	body := map[string]interface{}{
 		"instId":      instId,
-		"tdMode":      "cross",
+		"tdMode":      marginMode,
 		"side":        side,
 		"posSide":     posSide,
 		"ordType":     "conditional",
@@ -453,9 +459,11 @@ func (t *OKXTrader) SetTakeProfit(symbol string, positionSide string, quantity, 
 		posSide = "short"
 	}
 
+	marginMode := t.marginMode()
+
 	body := map[string]interface{}{
 		"instId":      instId,
-		"tdMode":      "cross",
+		"tdMode":      marginMode,
 		"side":        side,
 		"posSide":     posSide,
 		"ordType":     "conditional",
@@ -815,9 +823,11 @@ func (t *OKXTrader) PlaceLimitOrder(req *types.LimitOrderRequest) (*types.LimitO
 		posSide = "short"
 	}
 
+	marginMode := t.marginMode()
+
 	body := map[string]interface{}{
 		"instId":  instId,
-		"tdMode":  "cross",
+		"tdMode":  marginMode,
 		"side":    side,
 		"posSide": posSide,
 		"ordType": "limit",


### PR DESCRIPTION
# Pull Request - Backend

## 📝 Description

This PR combines two related backend fixes in the trader execution path:

1. Fix OKX margin mode handling so configured cross/isolated mode is respected consistently in leverage and order requests.
2. Fix NofxAI data routing for strategy-based trader flows so paid Nofx data sources always use the user's configured claw402 wallet, even when the selected inference model is a normal provider such as DeepSeek.

### OKX margin mode fix

Before this change, OKX trading behavior had two related problems:

1. Parts of the OKX leverage / order flow were effectively hardcoded to cross margin behavior, so the trader's configured cross/isolated mode was not fully honored.
2. `SetMarginMode()` attempted to call the legacy `/api/v5/account/set-isolated-mode` endpoint directly, which caused misleading `51000` API errors such as `Parameter isoMode error` and `Parameter type error`.

This PR makes OKX trading requests respect the configured margin mode end-to-end:

- leverage requests use the configured mode via `mgnMode`
- order and algo-order requests use the configured mode via `tdMode`

It also removes the invalid legacy `SetMarginMode()` API call and keeps margin mode as local configuration state for later OKX requests.

### NofxAI / claw402 wallet routing fix

Before this change, strategy-based trader flows could fall back to the process-level `CLAW402_WALLET_KEY` environment variable when no wallet key was passed explicitly into `StrategyEngine`.

That fallback was implicit and global rather than trader/user scoped. In practice, this made the real trader path less deterministic than the AI test path when a strategy used paid NofxAI data sources such as `ai500`, `oi ranking`, `netflow ranking`, or `price ranking`.

This PR makes the trader path consistent with the AI test path by explicitly resolving the user's configured `claw402` wallet and passing it into `StrategyEngine`, even when the selected AI model is not `claw402`.

As a result:

- normal models such as `deepseek` can still use NofxAI paid data
- NofxAI data payments consistently go through the user's claw402 wallet
- the trader path no longer relies on implicit env fallback for this behavior

---

## 🎯 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🔧 Build/config change

---

## 🔗 Related Issues

- Closes #
- Related to #

---

## 📋 Changes Made

- Fix OKX leverage flow so it no longer falls back to hardcoded cross margin behavior
- Fix OKX order / algo-order flow so it uses the configured cross/isolated mode
- Pass configured margin mode through:
  - `mgnMode` in leverage requests
  - `tdMode` in order and algo-order requests
- Remove the direct legacy `/api/v5/account/set-isolated-mode` call from `SetMarginMode()`
- Keep `SetMarginMode()` as local configuration state for subsequent OKX trading requests
- Improve logging to clearly show which margin mode is being configured and applied
- Add regression coverage to ensure the legacy endpoint is no longer called and future requests use the configured isolated mode correctly
- Add explicit `claw402` wallet propagation for trader strategy execution
- Resolve the user's `claw402` wallet during trader loading, even when the selected model is a normal provider such as `deepseek`
- Pass the resolved wallet key into `StrategyEngine` instead of relying on implicit env fallback
- Make trader-side NofxAI paid data routing consistent with the AI test path

---

## 🧪 Testing

### Test Environment
- **OS:** macOS
- **Go Version:** local project Go toolchain
- **Exchange:** OKX

### Manual Testing
- [x] Tested locally
- [ ] Tested on testnet (for exchange integration)
- [x] Unit tests pass
- [x] Verified no existing functionality broke

### Test Results
```bash
go test ./trader/okx
ok  	nofx/trader/okx	(cached)

go test ./trader ./manager ./api
ok  	nofx/trader	(cached)
?   	nofx/manager	[no test files]
ok  	nofx/api	0.480s
