### PR TITLE
fix(auth): prevent SetupPage remount from wiping freshly-set auth token

### DIFF
--- a/web/src/router/AppRoutes.tsx
+++ b/web/src/router/AppRoutes.tsx
@@ -439,7 +439,9 @@ export function AppRoutes() {
         <Route
           path={ROUTES.setup}
           element={
-            systemConfig?.initialized ? (
+            user ? (
+              <Navigate to={ROUTES.welcome} replace />
+            ) : systemConfig?.initialized ? (
               <Navigate to={ROUTES.login} replace />
             ) : (
               <SetupPage />


### PR DESCRIPTION
## Summary
- Fixes an auth regression introduced by #1470 where users are bounced back to the login screen after a fresh register.
- After #1470 moved routing into react-router, `SetupPage` is rendered at two tree positions (top-level guard + `/setup` Route). When register success flushSync-sets `user`, the top-level guard stops matching, so the Route-level `SetupPage` mounts as a new instance and its cleanup `useEffect` wipes the `auth_token` that `handlePostAuthSuccess` just wrote to localStorage. The next request 401s and redirects to `/login`.
- Fix: when `user` is already set, redirect `/setup` to `/welcome` so `SetupPage` is never re-mounted during the auth transition. 3-line change in `web/src/router/AppRoutes.tsx`.

## Test plan
- [x] Reproduced the bounce locally before the fix
- [x] Verified fresh register flow lands on `/welcome` without re-login after the fix
- [ ] Login flow unaffected
- [ ] Uninitialized-system first-boot `/setup` still reachable when no user exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)