### PR TITLE
refactor: remove NofxOS API key — all data requests now route through claw402

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -280,7 +280,6 @@ StrategyConfig fields:
   indicators.rsi_periods: [7,14] default
   indicators.atr_periods: [14] default
   indicators.boll_periods: [20] default
-  indicators.nofxos_api_key: ALWAYS "cm_568c67eae410d912c54c"
   indicators.enable_quant_data: ALWAYS true
   indicators.enable_quant_oi: ALWAYS true
   indicators.enable_quant_netflow: ALWAYS true

--- a/api/strategy.go
+++ b/api/strategy.go
@@ -21,13 +21,6 @@ import (
 func validateStrategyConfig(config *store.StrategyConfig) []string {
 	var warnings []string
 
-	// Validate NofxOS API key if any NofxOS feature is enabled
-	if (config.Indicators.EnableQuantData || config.Indicators.EnableOIRanking ||
-		config.Indicators.EnableNetFlowRanking || config.Indicators.EnablePriceRanking) &&
-		config.Indicators.NofxOSAPIKey == "" {
-		warnings = append(warnings, "NofxOS API key is not configured. NofxOS data sources may not work properly.")
-	}
-
 	return warnings
 }
 

--- a/kernel/engine.go
+++ b/kernel/engine.go
@@ -189,12 +189,8 @@ type StrategyEngine struct {
 // NewStrategyEngine creates strategy execution engine.
 // claw402WalletKey is optional — if provided, nofxos data requests are routed through claw402.
 func NewStrategyEngine(config *store.StrategyConfig, claw402WalletKey ...string) *StrategyEngine {
-	// Create NofxOS client with API key from config
-	apiKey := config.Indicators.NofxOSAPIKey
-	if apiKey == "" {
-		apiKey = nofxos.DefaultAuthKey
-	}
-	client := nofxos.NewClient(nofxos.DefaultBaseURL, apiKey)
+	// Create NofxOS client (authKey is empty — all requests now route through claw402)
+	client := nofxos.NewClient(nofxos.DefaultBaseURL, "")
 
 	// If claw402 wallet key is provided (from trader's AI config), route through claw402
 	walletKey := ""

--- a/provider/nofxos/client.go
+++ b/provider/nofxos/client.go
@@ -16,7 +16,6 @@ import (
 const (
 	DefaultBaseURL = "https://nofxos.ai"
 	DefaultTimeout = 30 * time.Second
-	DefaultAuthKey = "cm_568c67eae410d912c54c"
 )
 
 // Client is the NofxOS API client
@@ -38,7 +37,6 @@ func DefaultClient() *Client {
 	clientOnce.Do(func() {
 		defaultClient = &Client{
 			BaseURL: DefaultBaseURL,
-			AuthKey: DefaultAuthKey,
 			Timeout: DefaultTimeout,
 		}
 	})
@@ -49,9 +47,6 @@ func DefaultClient() *Client {
 func NewClient(baseURL, authKey string) *Client {
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
-	}
-	if authKey == "" {
-		authKey = DefaultAuthKey
 	}
 	return &Client{
 		BaseURL: baseURL,

--- a/store/strategy.go
+++ b/store/strategy.go
@@ -206,10 +206,6 @@ type IndicatorConfig struct {
 	// external data sources
 	ExternalDataSources []ExternalDataSource `json:"external_data_sources,omitempty"`
 
-	// ========== NofxOS Unified API Configuration ==========
-	// Unified API Key for all NofxOS data sources
-	NofxOSAPIKey string `json:"nofxos_api_key,omitempty"`
-
 	// quantitative data sources (capital flow, position changes, price changes)
 	EnableQuantData    bool `json:"enable_quant_data"`    // whether to enable quantitative data
 	EnableQuantOI      bool `json:"enable_quant_oi"`      // whether to show OI data
@@ -340,8 +336,6 @@ func GetDefaultStrategyConfig(lang string) StrategyConfig {
 			RSIPeriods:        []int{7, 14},
 			ATRPeriods:        []int{14},
 			BOLLPeriods:       []int{20},
-			// NofxOS unified API key
-			NofxOSAPIKey: "cm_568c67eae410d912c54c",
 			// Quant data
 			EnableQuantData:    true,
 			EnableQuantOI:      true,

--- a/web/src/components/strategy/CoinSourceEditor.tsx
+++ b/web/src/components/strategy/CoinSourceEditor.tsx
@@ -1,5 +1,15 @@
 import { useState } from 'react'
-import { Plus, X, Database, TrendingUp, TrendingDown, List, Ban, Zap, Shuffle } from 'lucide-react'
+import {
+  Plus,
+  X,
+  Database,
+  TrendingUp,
+  TrendingDown,
+  List,
+  Ban,
+  Zap,
+  Shuffle,
+} from 'lucide-react'
 import type { CoinSourceConfig } from '../../types'
 import { coinSource, ts } from '../../i18n/strategy-translations'
 import { NofxSelect } from '../ui/select'
@@ -37,15 +47,21 @@ export function CoinSourceEditor({
       totalLimit += config.ai500_limit || 3
     }
     if (config.use_oi_top) {
-      sources.push(`${ts(coinSource.oiIncreaseShort, language)}(${config.oi_top_limit || 3})`)
+      sources.push(
+        `${ts(coinSource.oiIncreaseShort, language)}(${config.oi_top_limit || 3})`
+      )
       totalLimit += config.oi_top_limit || 3
     }
     if (config.use_oi_low) {
-      sources.push(`${ts(coinSource.oiDecreaseShort, language)}(${config.oi_low_limit || 3})`)
+      sources.push(
+        `${ts(coinSource.oiDecreaseShort, language)}(${config.oi_low_limit || 3})`
+      )
       totalLimit += config.oi_low_limit || 3
     }
     if ((config.static_coins || []).length > 0) {
-      sources.push(`${ts(coinSource.custom, language)}(${config.static_coins?.length || 0})`)
+      sources.push(
+        `${ts(coinSource.custom, language)}(${config.static_coins?.length || 0})`
+      )
       totalLimit += config.static_coins?.length || 0
     }
 
@@ -55,19 +71,44 @@ export function CoinSourceEditor({
   // xyz dex assets (stocks, forex, commodities) - should NOT get USDT suffix
   const xyzDexAssets = new Set([
     // Stocks
-    'TSLA', 'NVDA', 'AAPL', 'MSFT', 'META', 'AMZN', 'GOOGL', 'AMD', 'COIN', 'NFLX',
-    'PLTR', 'HOOD', 'INTC', 'MSTR', 'TSM', 'ORCL', 'MU', 'RIVN', 'COST', 'LLY',
-    'CRCL', 'SKHX', 'SNDK',
+    'TSLA',
+    'NVDA',
+    'AAPL',
+    'MSFT',
+    'META',
+    'AMZN',
+    'GOOGL',
+    'AMD',
+    'COIN',
+    'NFLX',
+    'PLTR',
+    'HOOD',
+    'INTC',
+    'MSTR',
+    'TSM',
+    'ORCL',
+    'MU',
+    'RIVN',
+    'COST',
+    'LLY',
+    'CRCL',
+    'SKHX',
+    'SNDK',
     // Forex
-    'EUR', 'JPY',
+    'EUR',
+    'JPY',
     // Commodities
-    'GOLD', 'SILVER',
+    'GOLD',
+    'SILVER',
     // Index
     'XYZ100',
   ])
 
   const isXyzDexAsset = (symbol: string): boolean => {
-    const base = symbol.toUpperCase().replace(/^XYZ:/, '').replace(/USDT$|USD$|-USDC$/, '')
+    const base = symbol
+      .toUpperCase()
+      .replace(/^XYZ:/, '')
+      .replace(/USDT$|USD$|-USDC$/, '')
     return xyzDexAssets.has(base)
   }
 
@@ -76,7 +117,8 @@ export function CoinSourceEditor({
   const showToast = (msg: string) => {
     const toast = document.createElement('div')
     toast.textContent = msg
-    toast.className = 'fixed top-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded-lg text-sm z-50 shadow-lg'
+    toast.className =
+      'fixed top-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded-lg text-sm z-50 shadow-lg'
     toast.style.cssText = 'background:#F6465D;color:#fff;'
     document.body.appendChild(toast)
     setTimeout(() => toast.remove(), 2000)
@@ -87,7 +129,11 @@ export function CoinSourceEditor({
 
     const currentCoins = config.static_coins || []
     if (currentCoins.length >= MAX_STATIC_COINS) {
-      showToast(language === 'zh' ? `最多添加 ${MAX_STATIC_COINS} 个币种` : `Maximum ${MAX_STATIC_COINS} coins allowed`)
+      showToast(
+        language === 'zh'
+          ? `最多添加 ${MAX_STATIC_COINS} 个币种`
+          : `Maximum ${MAX_STATIC_COINS} coins allowed`
+      )
       return
     }
 
@@ -97,7 +143,9 @@ export function CoinSourceEditor({
     let formattedSymbol: string
     if (isXyzDexAsset(symbol)) {
       // Remove xyz: prefix (case-insensitive) and any USD suffixes
-      const base = symbol.replace(/^xyz:/i, '').replace(/USDT$|USD$|-USDC$/i, '')
+      const base = symbol
+        .replace(/^xyz:/i, '')
+        .replace(/USDT$|USD$|-USDC$/i, '')
       formattedSymbol = `xyz:${base}`
     } else {
       formattedSymbol = symbol.endsWith('USDT') ? symbol : `${symbol}USDT`
@@ -126,7 +174,9 @@ export function CoinSourceEditor({
     // For xyz dex assets, use xyz: prefix without USDT
     let formattedSymbol: string
     if (isXyzDexAsset(symbol)) {
-      const base = symbol.replace(/^xyz:/i, '').replace(/USDT$|USD$|-USDC$/i, '')
+      const base = symbol
+        .replace(/^xyz:/i, '')
+        .replace(/USDT$|USD$|-USDC$/i, '')
       formattedSymbol = `xyz:${base}`
     } else {
       formattedSymbol = symbol.endsWith('USDT') ? symbol : `${symbol}USDT`
@@ -151,9 +201,7 @@ export function CoinSourceEditor({
 
   // NofxOS badge component
   const NofxOSBadge = () => (
-    <span
-      className="text-[9px] px-1.5 py-0.5 rounded font-medium bg-purple-500/20 text-purple-400 border border-purple-500/30"
-    >
+    <span className="text-[9px] px-1.5 py-0.5 rounded font-medium bg-purple-500/20 text-purple-400 border border-purple-500/30">
       NofxOS
     </span>
   )
@@ -171,20 +219,27 @@ export function CoinSourceEditor({
               key={value}
               onClick={() =>
                 !disabled &&
-                onChange({ ...config, source_type: value as CoinSourceConfig['source_type'] })
+                onChange({
+                  ...config,
+                  source_type: value as CoinSourceConfig['source_type'],
+                })
               }
               disabled={disabled}
-              className={`p-4 rounded-lg border transition-all ${config.source_type === value
-                ? 'ring-2 ring-nofx-gold bg-nofx-gold/10'
-                : 'hover:bg-white/5 bg-nofx-bg'
-                } border-nofx-gold/20`}
+              className={`p-4 rounded-lg border transition-all ${
+                config.source_type === value
+                  ? 'ring-2 ring-nofx-gold bg-nofx-gold/10'
+                  : 'hover:bg-white/5 bg-nofx-bg'
+              } border-nofx-gold/20`}
             >
               <Icon className="w-6 h-6 mx-auto mb-2" style={{ color }} />
               <div className="text-sm font-medium text-nofx-text">
                 {ts(coinSource[value as keyof typeof coinSource], language)}
               </div>
               <div className="text-xs mt-1 text-nofx-text-muted">
-                {ts(coinSource[`${value}Desc` as keyof typeof coinSource], language)}
+                {ts(
+                  coinSource[`${value}Desc` as keyof typeof coinSource],
+                  language
+                )}
               </div>
             </button>
           ))}
@@ -294,9 +349,7 @@ export function CoinSourceEditor({
 
       {/* AI500 Options - only for ai500 mode */}
       {config.source_type === 'ai500' && (
-        <div
-          className="p-4 rounded-lg bg-nofx-gold/5 border border-nofx-gold/20"
-        >
+        <div className="p-4 rounded-lg bg-nofx-gold/5 border border-nofx-gold/20">
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
               <Zap className="w-4 h-4 text-nofx-gold" />
@@ -313,12 +366,15 @@ export function CoinSourceEditor({
                 type="checkbox"
                 checked={config.use_ai500}
                 onChange={(e) =>
-                  !disabled && onChange({ ...config, use_ai500: e.target.checked })
+                  !disabled &&
+                  onChange({ ...config, use_ai500: e.target.checked })
                 }
                 disabled={disabled}
                 className="w-5 h-5 rounded accent-nofx-gold"
               />
-              <span className="text-nofx-text">{ts(coinSource.useAI500, language)}</span>
+              <span className="text-nofx-text">
+                {ts(coinSource.useAI500, language)}
+              </span>
             </label>
 
             {config.use_ai500 && (
@@ -333,29 +389,27 @@ export function CoinSourceEditor({
                     onChange({ ...config, ai500_limit: parseInt(val) || 3 })
                   }
                   disabled={disabled}
-                  options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(n => ({ value: n, label: String(n) }))}
+                  options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => ({
+                    value: n,
+                    label: String(n),
+                  }))}
                   className="px-3 py-1.5 rounded bg-nofx-bg border border-nofx-gold/20 text-nofx-text"
                 />
               </div>
             )}
-
-            <p className="text-xs pl-8 text-nofx-text-muted">
-              {ts(coinSource.nofxosNote, language)}
-            </p>
           </div>
         </div>
       )}
 
       {/* OI Top Options - only for oi_top mode */}
       {config.source_type === 'oi_top' && (
-        <div
-          className="p-4 rounded-lg bg-nofx-success/5 border border-nofx-success/20"
-        >
+        <div className="p-4 rounded-lg bg-nofx-success/5 border border-nofx-success/20">
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
               <TrendingUp className="w-4 h-4 text-nofx-success" />
               <span className="text-sm font-medium text-nofx-text">
-                {ts(coinSource.oiIncreaseTitle, language)} {ts(coinSource.dataSourceConfig, language)}
+                {ts(coinSource.oiIncreaseTitle, language)}{' '}
+                {ts(coinSource.dataSourceConfig, language)}
               </span>
               <NofxOSBadge />
             </div>
@@ -367,12 +421,15 @@ export function CoinSourceEditor({
                 type="checkbox"
                 checked={config.use_oi_top}
                 onChange={(e) =>
-                  !disabled && onChange({ ...config, use_oi_top: e.target.checked })
+                  !disabled &&
+                  onChange({ ...config, use_oi_top: e.target.checked })
                 }
                 disabled={disabled}
                 className="w-5 h-5 rounded accent-nofx-success"
               />
-              <span className="text-nofx-text">{ts(coinSource.useOITop, language)}</span>
+              <span className="text-nofx-text">
+                {ts(coinSource.useOITop, language)}
+              </span>
             </label>
 
             {config.use_oi_top && (
@@ -387,29 +444,27 @@ export function CoinSourceEditor({
                     onChange({ ...config, oi_top_limit: parseInt(val) || 3 })
                   }
                   disabled={disabled}
-                  options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(n => ({ value: n, label: String(n) }))}
+                  options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => ({
+                    value: n,
+                    label: String(n),
+                  }))}
                   className="px-3 py-1.5 rounded bg-nofx-bg border border-nofx-gold/20 text-nofx-text"
                 />
               </div>
             )}
-
-            <p className="text-xs pl-8 text-nofx-text-muted">
-              {ts(coinSource.nofxosNote, language)}
-            </p>
           </div>
         </div>
       )}
 
       {/* OI Low Options - only for oi_low mode */}
       {config.source_type === 'oi_low' && (
-        <div
-          className="p-4 rounded-lg bg-nofx-danger/5 border border-nofx-danger/20"
-        >
+        <div className="p-4 rounded-lg bg-nofx-danger/5 border border-nofx-danger/20">
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
               <TrendingDown className="w-4 h-4 text-nofx-danger" />
               <span className="text-sm font-medium text-nofx-text">
-                {ts(coinSource.oiDecreaseTitle, language)} {ts(coinSource.dataSourceConfig, language)}
+                {ts(coinSource.oiDecreaseTitle, language)}{' '}
+                {ts(coinSource.dataSourceConfig, language)}
               </span>
               <NofxOSBadge />
             </div>
@@ -421,12 +476,15 @@ export function CoinSourceEditor({
                 type="checkbox"
                 checked={config.use_oi_low}
                 onChange={(e) =>
-                  !disabled && onChange({ ...config, use_oi_low: e.target.checked })
+                  !disabled &&
+                  onChange({ ...config, use_oi_low: e.target.checked })
                 }
                 disabled={disabled}
                 className="w-5 h-5 rounded accent-red-500"
               />
-              <span className="text-nofx-text">{ts(coinSource.useOILow, language)}</span>
+              <span className="text-nofx-text">
+                {ts(coinSource.useOILow, language)}
+              </span>
             </label>
 
             {config.use_oi_low && (
@@ -441,15 +499,14 @@ export function CoinSourceEditor({
                     onChange({ ...config, oi_low_limit: parseInt(val) || 3 })
                   }
                   disabled={disabled}
-                  options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(n => ({ value: n, label: String(n) }))}
+                  options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => ({
+                    value: n,
+                    label: String(n),
+                  }))}
                   className="px-3 py-1.5 rounded bg-nofx-bg border border-nofx-gold/20 text-nofx-text"
                 />
               </div>
             )}
-
-            <p className="text-xs pl-8 text-nofx-text-muted">
-              {ts(coinSource.nofxosNote, language)}
-            </p>
           </div>
         </div>
       )}
@@ -473,19 +530,27 @@ export function CoinSourceEditor({
                   ? 'bg-nofx-gold/10 border-nofx-gold/50'
                   : 'bg-nofx-bg border-nofx-border hover:border-nofx-gold/30'
               }`}
-              onClick={() => !disabled && onChange({ ...config, use_ai500: !config.use_ai500 })}
+              onClick={() =>
+                !disabled &&
+                onChange({ ...config, use_ai500: !config.use_ai500 })
+              }
             >
               <div className="flex items-center gap-2 mb-2">
                 <input
                   type="checkbox"
                   checked={config.use_ai500}
-                  onChange={(e) => !disabled && onChange({ ...config, use_ai500: e.target.checked })}
+                  onChange={(e) =>
+                    !disabled &&
+                    onChange({ ...config, use_ai500: e.target.checked })
+                  }
                   disabled={disabled}
                   className="w-4 h-4 rounded accent-nofx-gold"
                   onClick={(e) => e.stopPropagation()}
                 />
                 <Database className="w-4 h-4 text-nofx-gold" />
-                <span className="text-sm font-medium text-nofx-text">AI500</span>
+                <span className="text-sm font-medium text-nofx-text">
+                  AI500
+                </span>
                 <NofxOSBadge />
               </div>
               {config.use_ai500 && (
@@ -493,9 +558,15 @@ export function CoinSourceEditor({
                   <span className="text-xs text-nofx-text-muted">Limit:</span>
                   <NofxSelect
                     value={config.ai500_limit || 3}
-                    onChange={(val) => !disabled && onChange({ ...config, ai500_limit: parseInt(val) || 3 })}
+                    onChange={(val) =>
+                      !disabled &&
+                      onChange({ ...config, ai500_limit: parseInt(val) || 3 })
+                    }
                     disabled={disabled}
-                    options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(n => ({ value: n, label: String(n) }))}
+                    options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => ({
+                      value: n,
+                      label: String(n),
+                    }))}
                     className="px-2 py-1 rounded text-xs bg-nofx-bg border border-nofx-gold/20 text-nofx-text"
                   />
                 </div>
@@ -509,13 +580,19 @@ export function CoinSourceEditor({
                   ? 'bg-nofx-success/10 border-nofx-success/50'
                   : 'bg-nofx-bg border-nofx-border hover:border-nofx-success/30'
               }`}
-              onClick={() => !disabled && onChange({ ...config, use_oi_top: !config.use_oi_top })}
+              onClick={() =>
+                !disabled &&
+                onChange({ ...config, use_oi_top: !config.use_oi_top })
+              }
             >
               <div className="flex items-center gap-2 mb-2">
                 <input
                   type="checkbox"
                   checked={config.use_oi_top}
-                  onChange={(e) => !disabled && onChange({ ...config, use_oi_top: e.target.checked })}
+                  onChange={(e) =>
+                    !disabled &&
+                    onChange({ ...config, use_oi_top: e.target.checked })
+                  }
                   disabled={disabled}
                   className="w-4 h-4 rounded accent-nofx-success"
                   onClick={(e) => e.stopPropagation()}
@@ -533,9 +610,15 @@ export function CoinSourceEditor({
                   <span className="text-xs text-nofx-text-muted">Limit:</span>
                   <NofxSelect
                     value={config.oi_top_limit || 3}
-                    onChange={(val) => !disabled && onChange({ ...config, oi_top_limit: parseInt(val) || 3 })}
+                    onChange={(val) =>
+                      !disabled &&
+                      onChange({ ...config, oi_top_limit: parseInt(val) || 3 })
+                    }
                     disabled={disabled}
-                    options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(n => ({ value: n, label: String(n) }))}
+                    options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => ({
+                      value: n,
+                      label: String(n),
+                    }))}
                     className="px-2 py-1 rounded text-xs bg-nofx-bg border border-nofx-gold/20 text-nofx-text"
                   />
                 </div>
@@ -549,13 +632,19 @@ export function CoinSourceEditor({
                   ? 'bg-nofx-danger/10 border-nofx-danger/50'
                   : 'bg-nofx-bg border-nofx-border hover:border-nofx-danger/30'
               }`}
-              onClick={() => !disabled && onChange({ ...config, use_oi_low: !config.use_oi_low })}
+              onClick={() =>
+                !disabled &&
+                onChange({ ...config, use_oi_low: !config.use_oi_low })
+              }
             >
               <div className="flex items-center gap-2 mb-2">
                 <input
                   type="checkbox"
                   checked={config.use_oi_low}
-                  onChange={(e) => !disabled && onChange({ ...config, use_oi_low: e.target.checked })}
+                  onChange={(e) =>
+                    !disabled &&
+                    onChange({ ...config, use_oi_low: e.target.checked })
+                  }
                   disabled={disabled}
                   className="w-4 h-4 rounded accent-red-500"
                   onClick={(e) => e.stopPropagation()}
@@ -573,9 +662,15 @@ export function CoinSourceEditor({
                   <span className="text-xs text-nofx-text-muted">Limit:</span>
                   <NofxSelect
                     value={config.oi_low_limit || 3}
-                    onChange={(val) => !disabled && onChange({ ...config, oi_low_limit: parseInt(val) || 3 })}
+                    onChange={(val) =>
+                      !disabled &&
+                      onChange({ ...config, oi_low_limit: parseInt(val) || 3 })
+                    }
                     disabled={disabled}
-                    options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(n => ({ value: n, label: String(n) }))}
+                    options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => ({
+                      value: n,
+                      label: String(n),
+                    }))}
                     className="px-2 py-1 rounded text-xs bg-nofx-bg border border-nofx-gold/20 text-nofx-text"
                   />
                 </div>
@@ -662,13 +757,16 @@ export function CoinSourceEditor({
             return (
               <div className="p-2 rounded bg-nofx-bg border border-nofx-border">
                 <div className="flex items-center justify-between text-xs">
-                  <span className="text-nofx-text-muted">{ts(coinSource.mixedSummary, language)}:</span>
+                  <span className="text-nofx-text-muted">
+                    {ts(coinSource.mixedSummary, language)}:
+                  </span>
                   <span className="text-nofx-text font-medium">
                     {sources.join(' + ')}
                   </span>
                 </div>
                 <div className="text-xs text-nofx-text-muted mt-1">
-                  {ts(coinSource.maxCoins, language)} {totalLimit} {ts(coinSource.coins, language)}
+                  {ts(coinSource.maxCoins, language)} {totalLimit}{' '}
+                  {ts(coinSource.coins, language)}
                 </div>
               </div>
             )

--- a/web/src/components/strategy/IndicatorEditor.tsx
+++ b/web/src/components/strategy/IndicatorEditor.tsx
@@ -1,10 +1,16 @@
-import { Clock, Activity, TrendingUp, BarChart2, Info, Lock, ExternalLink, Zap, Check, AlertCircle, Key } from 'lucide-react'
+import {
+  Clock,
+  Activity,
+  TrendingUp,
+  BarChart2,
+  Info,
+  Lock,
+  ExternalLink,
+  Zap,
+} from 'lucide-react'
 import type { IndicatorConfig } from '../../types'
 import { indicator, ts } from '../../i18n/strategy-translations'
 import { NofxSelect } from '../ui/select'
-
-// Default NofxOS API Key
-const DEFAULT_NOFXOS_API_KEY = 'cm_568c67eae410d912c54c'
 
 interface IndicatorEditorProps {
   config: IndicatorConfig
@@ -38,7 +44,9 @@ export function IndicatorEditor({
   language,
 }: IndicatorEditorProps) {
   // Get currently selected timeframes
-  const selectedTimeframes = config.klines.selected_timeframes || [config.klines.primary_timeframe]
+  const selectedTimeframes = config.klines.selected_timeframes || [
+    config.klines.primary_timeframe,
+  ]
 
   // Toggle timeframe selection
   const toggleTimeframe = (tf: string) => {
@@ -49,7 +57,10 @@ export function IndicatorEditor({
     if (index >= 0) {
       if (current.length > 1) {
         current.splice(index, 1)
-        const newPrimary = tf === config.klines.primary_timeframe ? current[0] : config.klines.primary_timeframe
+        const newPrimary =
+          tf === config.klines.primary_timeframe
+            ? current[0]
+            : config.klines.primary_timeframe
         onChange({
           ...config,
           klines: {
@@ -64,8 +75,12 @@ export function IndicatorEditor({
       if (current.length >= 4) {
         // Show toast notification
         const toast = document.createElement('div')
-        toast.textContent = language === 'zh' ? '最多选择 4 个时间维度' : 'Maximum 4 timeframes allowed'
-        toast.className = 'fixed top-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded-lg text-sm z-50 shadow-lg'
+        toast.textContent =
+          language === 'zh'
+            ? '最多选择 4 个时间维度'
+            : 'Maximum 4 timeframes allowed'
+        toast.className =
+          'fixed top-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded-lg text-sm z-50 shadow-lg'
         toast.style.cssText = 'background:#F6465D;color:#fff;'
         document.body.appendChild(toast)
         setTimeout(() => toast.remove(), 2000)
@@ -110,14 +125,14 @@ export function IndicatorEditor({
   }
 
   // Call on mount if needed
-  if (config.enable_raw_klines === undefined || config.enable_raw_klines === false) {
+  if (
+    config.enable_raw_klines === undefined ||
+    config.enable_raw_klines === false
+  ) {
     ensureRawKlines()
   }
 
   // Check if any NofxOS feature is enabled
-  const hasNofxosEnabled = config.enable_quant_data || config.enable_oi_ranking || config.enable_netflow_ranking || config.enable_price_ranking
-  const hasApiKey = !!config.nofxos_api_key
-
   return (
     <div className="space-y-5">
       {/* ============================================ */}
@@ -126,14 +141,17 @@ export function IndicatorEditor({
       <div
         className="rounded-lg overflow-hidden relative"
         style={{
-          background: 'linear-gradient(135deg, rgba(99, 102, 241, 0.08) 0%, rgba(168, 85, 247, 0.08) 50%, rgba(236, 72, 153, 0.08) 100%)',
+          background:
+            'linear-gradient(135deg, rgba(99, 102, 241, 0.08) 0%, rgba(168, 85, 247, 0.08) 50%, rgba(236, 72, 153, 0.08) 100%)',
           border: '1px solid rgba(139, 92, 246, 0.3)',
         }}
       >
         {/* Decorative gradient line at top */}
         <div
           className="absolute top-0 left-0 right-0 h-[2px]"
-          style={{ background: 'linear-gradient(90deg, #6366f1, #a855f7, #ec4899)' }}
+          style={{
+            background: 'linear-gradient(90deg, #6366f1, #a855f7, #ec4899)',
+          }}
         />
 
         <div className="p-4">
@@ -142,12 +160,17 @@ export function IndicatorEditor({
             <div className="flex items-center gap-2">
               <div
                 className="w-8 h-8 rounded-lg flex items-center justify-center"
-                style={{ background: 'linear-gradient(135deg, #6366f1, #a855f7)' }}
+                style={{
+                  background: 'linear-gradient(135deg, #6366f1, #a855f7)',
+                }}
               >
                 <Zap className="w-4 h-4 text-white" />
               </div>
               <div>
-                <h3 className="text-sm font-semibold" style={{ color: '#EAECEF' }}>
+                <h3
+                  className="text-sm font-semibold"
+                  style={{ color: '#EAECEF' }}
+                >
                   {ts(indicator.nofxosTitle, language)}
                 </h3>
                 <span className="text-[10px]" style={{ color: '#848E9C' }}>
@@ -156,19 +179,8 @@ export function IndicatorEditor({
               </div>
             </div>
 
-            {/* Status & API Docs */}
+            {/* API Docs */}
             <div className="flex items-center gap-2">
-              {hasApiKey ? (
-                <span className="flex items-center gap-1 text-[10px] px-2 py-1 rounded-full" style={{ background: 'rgba(14, 203, 129, 0.15)', color: '#0ECB81' }}>
-                  <Check className="w-3 h-3" />
-                  {ts(indicator.connected, language)}
-                </span>
-              ) : (
-                <span className="flex items-center gap-1 text-[10px] px-2 py-1 rounded-full" style={{ background: 'rgba(246, 70, 93, 0.15)', color: '#F6465D' }}>
-                  <AlertCircle className="w-3 h-3" />
-                  {ts(indicator.notConfigured, language)}
-                </span>
-              )}
               <a
                 href="https://nofxos.ai/api-docs"
                 target="_blank"
@@ -185,42 +197,12 @@ export function IndicatorEditor({
             </div>
           </div>
 
-          {/* API Key Input */}
-          <div className="flex items-center gap-2">
-            <div className="flex-1 relative">
-              <Key className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: '#848E9C' }} />
-              <input
-                type="text"
-                value={config.nofxos_api_key || ''}
-                onChange={(e) => !disabled && onChange({ ...config, nofxos_api_key: e.target.value })}
-                disabled={disabled}
-                placeholder={ts(indicator.apiKeyPlaceholder, language)}
-                className="w-full pl-9 pr-3 py-2 rounded-lg text-sm font-mono"
-                style={{
-                  background: 'rgba(30, 35, 41, 0.8)',
-                  border: hasApiKey ? '1px solid rgba(14, 203, 129, 0.3)' : '1px solid rgba(139, 92, 246, 0.3)',
-                  color: '#EAECEF',
-                }}
-              />
-            </div>
-            {!disabled && !config.nofxos_api_key && (
-              <button
-                type="button"
-                onClick={() => onChange({ ...config, nofxos_api_key: DEFAULT_NOFXOS_API_KEY })}
-                className="px-3 py-2 rounded-lg text-xs font-medium transition-all hover:scale-[1.02]"
-                style={{
-                  background: 'linear-gradient(135deg, #6366f1, #a855f7)',
-                  color: '#fff',
-                }}
-              >
-                {ts(indicator.fillDefault, language)}
-              </button>
-            )}
-          </div>
-
           {/* NofxOS Data Sources Grid */}
           <div className="mt-4">
-            <div className="text-[10px] font-medium mb-2" style={{ color: '#848E9C' }}>
+            <div
+              className="text-[10px] font-medium mb-2"
+              style={{ color: '#848E9C' }}
+            >
               {ts(indicator.nofxosDataSources, language)}
             </div>
             <div className="grid grid-cols-2 gap-2">
@@ -228,47 +210,98 @@ export function IndicatorEditor({
               <div
                 className="p-2.5 rounded-lg transition-all cursor-pointer"
                 style={{
-                  background: config.enable_quant_data ? 'rgba(96, 165, 250, 0.1)' : 'rgba(30, 35, 41, 0.5)',
-                  border: config.enable_quant_data ? '1px solid rgba(96, 165, 250, 0.3)' : '1px solid rgba(43, 49, 57, 0.5)',
+                  background: config.enable_quant_data
+                    ? 'rgba(96, 165, 250, 0.1)'
+                    : 'rgba(30, 35, 41, 0.5)',
+                  border: config.enable_quant_data
+                    ? '1px solid rgba(96, 165, 250, 0.3)'
+                    : '1px solid rgba(43, 49, 57, 0.5)',
                   opacity: disabled ? 0.5 : 1,
                 }}
-                onClick={() => !disabled && onChange({ ...config, enable_quant_data: !config.enable_quant_data })}
+                onClick={() =>
+                  !disabled &&
+                  onChange({
+                    ...config,
+                    enable_quant_data: !config.enable_quant_data,
+                  })
+                }
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full" style={{ background: '#60a5fa' }} />
-                    <span className="text-xs font-medium" style={{ color: '#EAECEF' }}>{ts(indicator.quantData, language)}</span>
+                    <div
+                      className="w-2 h-2 rounded-full"
+                      style={{ background: '#60a5fa' }}
+                    />
+                    <span
+                      className="text-xs font-medium"
+                      style={{ color: '#EAECEF' }}
+                    >
+                      {ts(indicator.quantData, language)}
+                    </span>
                   </div>
                   <input
                     type="checkbox"
                     checked={config.enable_quant_data || false}
-                    onChange={(e) => { e.stopPropagation(); !disabled && onChange({ ...config, enable_quant_data: e.target.checked }) }}
+                    onChange={(e) => {
+                      e.stopPropagation()
+                      !disabled &&
+                        onChange({
+                          ...config,
+                          enable_quant_data: e.target.checked,
+                        })
+                    }}
                     disabled={disabled}
                     className="w-3.5 h-3.5 rounded accent-blue-500"
                   />
                 </div>
-                <p className="text-[10px] mt-1" style={{ color: '#5E6673' }}>{ts(indicator.quantDataDesc, language)}</p>
+                <p className="text-[10px] mt-1" style={{ color: '#5E6673' }}>
+                  {ts(indicator.quantDataDesc, language)}
+                </p>
                 {config.enable_quant_data && (
                   <div className="flex gap-3 mt-2">
                     <label className="flex items-center gap-1.5 cursor-pointer">
                       <input
                         type="checkbox"
                         checked={config.enable_quant_oi !== false}
-                        onChange={(e) => { e.stopPropagation(); !disabled && onChange({ ...config, enable_quant_oi: e.target.checked }) }}
+                        onChange={(e) => {
+                          e.stopPropagation()
+                          !disabled &&
+                            onChange({
+                              ...config,
+                              enable_quant_oi: e.target.checked,
+                            })
+                        }}
                         disabled={disabled}
                         className="w-3 h-3 rounded accent-blue-500"
                       />
-                      <span className="text-[10px]" style={{ color: '#EAECEF' }}>OI</span>
+                      <span
+                        className="text-[10px]"
+                        style={{ color: '#EAECEF' }}
+                      >
+                        OI
+                      </span>
                     </label>
                     <label className="flex items-center gap-1.5 cursor-pointer">
                       <input
                         type="checkbox"
                         checked={config.enable_quant_netflow !== false}
-                        onChange={(e) => { e.stopPropagation(); !disabled && onChange({ ...config, enable_quant_netflow: e.target.checked }) }}
+                        onChange={(e) => {
+                          e.stopPropagation()
+                          !disabled &&
+                            onChange({
+                              ...config,
+                              enable_quant_netflow: e.target.checked,
+                            })
+                        }}
                         disabled={disabled}
                         className="w-3 h-3 rounded accent-blue-500"
                       />
-                      <span className="text-[10px]" style={{ color: '#EAECEF' }}>Netflow</span>
+                      <span
+                        className="text-[10px]"
+                        style={{ color: '#EAECEF' }}
+                      >
+                        Netflow
+                      </span>
                     </label>
                   </div>
                 )}
@@ -278,53 +311,106 @@ export function IndicatorEditor({
               <div
                 className="p-2.5 rounded-lg transition-all cursor-pointer"
                 style={{
-                  background: config.enable_oi_ranking ? 'rgba(34, 197, 94, 0.1)' : 'rgba(30, 35, 41, 0.5)',
-                  border: config.enable_oi_ranking ? '1px solid rgba(34, 197, 94, 0.3)' : '1px solid rgba(43, 49, 57, 0.5)',
+                  background: config.enable_oi_ranking
+                    ? 'rgba(34, 197, 94, 0.1)'
+                    : 'rgba(30, 35, 41, 0.5)',
+                  border: config.enable_oi_ranking
+                    ? '1px solid rgba(34, 197, 94, 0.3)'
+                    : '1px solid rgba(43, 49, 57, 0.5)',
                   opacity: disabled ? 0.5 : 1,
                 }}
-                onClick={() => !disabled && onChange({
-                  ...config,
-                  enable_oi_ranking: !config.enable_oi_ranking,
-                  ...(!config.enable_oi_ranking && !config.oi_ranking_duration ? { oi_ranking_duration: '1h' } : {}),
-                  ...(!config.enable_oi_ranking && !config.oi_ranking_limit ? { oi_ranking_limit: 10 } : {}),
-                })}
+                onClick={() =>
+                  !disabled &&
+                  onChange({
+                    ...config,
+                    enable_oi_ranking: !config.enable_oi_ranking,
+                    ...(!config.enable_oi_ranking && !config.oi_ranking_duration
+                      ? { oi_ranking_duration: '1h' }
+                      : {}),
+                    ...(!config.enable_oi_ranking && !config.oi_ranking_limit
+                      ? { oi_ranking_limit: 10 }
+                      : {}),
+                  })
+                }
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full" style={{ background: '#22c55e' }} />
-                    <span className="text-xs font-medium" style={{ color: '#EAECEF' }}>{ts(indicator.oiRanking, language)}</span>
+                    <div
+                      className="w-2 h-2 rounded-full"
+                      style={{ background: '#22c55e' }}
+                    />
+                    <span
+                      className="text-xs font-medium"
+                      style={{ color: '#EAECEF' }}
+                    >
+                      {ts(indicator.oiRanking, language)}
+                    </span>
                   </div>
                   <input
                     type="checkbox"
                     checked={config.enable_oi_ranking || false}
-                    onChange={(e) => { e.stopPropagation(); !disabled && onChange({
-                      ...config,
-                      enable_oi_ranking: e.target.checked,
-                      ...(e.target.checked && !config.oi_ranking_duration ? { oi_ranking_duration: '1h' } : {}),
-                      ...(e.target.checked && !config.oi_ranking_limit ? { oi_ranking_limit: 10 } : {}),
-                    }) }}
+                    onChange={(e) => {
+                      e.stopPropagation()
+                      !disabled &&
+                        onChange({
+                          ...config,
+                          enable_oi_ranking: e.target.checked,
+                          ...(e.target.checked && !config.oi_ranking_duration
+                            ? { oi_ranking_duration: '1h' }
+                            : {}),
+                          ...(e.target.checked && !config.oi_ranking_limit
+                            ? { oi_ranking_limit: 10 }
+                            : {}),
+                        })
+                    }}
                     disabled={disabled}
                     className="w-3.5 h-3.5 rounded accent-green-500"
                   />
                 </div>
-                <p className="text-[10px] mt-1" style={{ color: '#5E6673' }}>{ts(indicator.oiRankingDesc, language)}</p>
+                <p className="text-[10px] mt-1" style={{ color: '#5E6673' }}>
+                  {ts(indicator.oiRankingDesc, language)}
+                </p>
                 {config.enable_oi_ranking && (
-                  <div className="flex gap-2 mt-2" onClick={(e) => e.stopPropagation()}>
+                  <div
+                    className="flex gap-2 mt-2"
+                    onClick={(e) => e.stopPropagation()}
+                  >
                     <NofxSelect
                       value={config.oi_ranking_duration || '1h'}
-                      onChange={(val) => !disabled && onChange({ ...config, oi_ranking_duration: val })}
+                      onChange={(val) =>
+                        !disabled &&
+                        onChange({ ...config, oi_ranking_duration: val })
+                      }
                       disabled={disabled}
                       className="flex-1 px-2 py-1 rounded text-[10px]"
-                      style={{ background: '#1E2329', border: '1px solid #2B3139', color: '#EAECEF' }}
-                      options={[{ value: '1h', label: '1h' }, { value: '4h', label: '4h' }, { value: '24h', label: '24h' }]}
+                      style={{
+                        background: '#1E2329',
+                        border: '1px solid #2B3139',
+                        color: '#EAECEF',
+                      }}
+                      options={[
+                        { value: '1h', label: '1h' },
+                        { value: '4h', label: '4h' },
+                        { value: '24h', label: '24h' },
+                      ]}
                     />
                     <NofxSelect
                       value={config.oi_ranking_limit || 10}
-                      onChange={(val) => !disabled && onChange({ ...config, oi_ranking_limit: parseInt(val) })}
+                      onChange={(val) =>
+                        !disabled &&
+                        onChange({ ...config, oi_ranking_limit: parseInt(val) })
+                      }
                       disabled={disabled}
                       className="w-14 px-2 py-1 rounded text-[10px]"
-                      style={{ background: '#1E2329', border: '1px solid #2B3139', color: '#EAECEF' }}
-                      options={[5, 10, 15, 20].map(n => ({ value: n, label: String(n) }))}
+                      style={{
+                        background: '#1E2329',
+                        border: '1px solid #2B3139',
+                        color: '#EAECEF',
+                      }}
+                      options={[5, 10, 15, 20].map((n) => ({
+                        value: n,
+                        label: String(n),
+                      }))}
                     />
                   </div>
                 )}
@@ -334,53 +420,112 @@ export function IndicatorEditor({
               <div
                 className="p-2.5 rounded-lg transition-all cursor-pointer"
                 style={{
-                  background: config.enable_netflow_ranking ? 'rgba(245, 158, 11, 0.1)' : 'rgba(30, 35, 41, 0.5)',
-                  border: config.enable_netflow_ranking ? '1px solid rgba(245, 158, 11, 0.3)' : '1px solid rgba(43, 49, 57, 0.5)',
+                  background: config.enable_netflow_ranking
+                    ? 'rgba(245, 158, 11, 0.1)'
+                    : 'rgba(30, 35, 41, 0.5)',
+                  border: config.enable_netflow_ranking
+                    ? '1px solid rgba(245, 158, 11, 0.3)'
+                    : '1px solid rgba(43, 49, 57, 0.5)',
                   opacity: disabled ? 0.5 : 1,
                 }}
-                onClick={() => !disabled && onChange({
-                  ...config,
-                  enable_netflow_ranking: !config.enable_netflow_ranking,
-                  ...(!config.enable_netflow_ranking && !config.netflow_ranking_duration ? { netflow_ranking_duration: '1h' } : {}),
-                  ...(!config.enable_netflow_ranking && !config.netflow_ranking_limit ? { netflow_ranking_limit: 10 } : {}),
-                })}
+                onClick={() =>
+                  !disabled &&
+                  onChange({
+                    ...config,
+                    enable_netflow_ranking: !config.enable_netflow_ranking,
+                    ...(!config.enable_netflow_ranking &&
+                    !config.netflow_ranking_duration
+                      ? { netflow_ranking_duration: '1h' }
+                      : {}),
+                    ...(!config.enable_netflow_ranking &&
+                    !config.netflow_ranking_limit
+                      ? { netflow_ranking_limit: 10 }
+                      : {}),
+                  })
+                }
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full" style={{ background: '#f59e0b' }} />
-                    <span className="text-xs font-medium" style={{ color: '#EAECEF' }}>{ts(indicator.netflowRanking, language)}</span>
+                    <div
+                      className="w-2 h-2 rounded-full"
+                      style={{ background: '#f59e0b' }}
+                    />
+                    <span
+                      className="text-xs font-medium"
+                      style={{ color: '#EAECEF' }}
+                    >
+                      {ts(indicator.netflowRanking, language)}
+                    </span>
                   </div>
                   <input
                     type="checkbox"
                     checked={config.enable_netflow_ranking || false}
-                    onChange={(e) => { e.stopPropagation(); !disabled && onChange({
-                      ...config,
-                      enable_netflow_ranking: e.target.checked,
-                      ...(e.target.checked && !config.netflow_ranking_duration ? { netflow_ranking_duration: '1h' } : {}),
-                      ...(e.target.checked && !config.netflow_ranking_limit ? { netflow_ranking_limit: 10 } : {}),
-                    }) }}
+                    onChange={(e) => {
+                      e.stopPropagation()
+                      !disabled &&
+                        onChange({
+                          ...config,
+                          enable_netflow_ranking: e.target.checked,
+                          ...(e.target.checked &&
+                          !config.netflow_ranking_duration
+                            ? { netflow_ranking_duration: '1h' }
+                            : {}),
+                          ...(e.target.checked && !config.netflow_ranking_limit
+                            ? { netflow_ranking_limit: 10 }
+                            : {}),
+                        })
+                    }}
                     disabled={disabled}
                     className="w-3.5 h-3.5 rounded accent-amber-500"
                   />
                 </div>
-                <p className="text-[10px] mt-1" style={{ color: '#5E6673' }}>{ts(indicator.netflowRankingDesc, language)}</p>
+                <p className="text-[10px] mt-1" style={{ color: '#5E6673' }}>
+                  {ts(indicator.netflowRankingDesc, language)}
+                </p>
                 {config.enable_netflow_ranking && (
-                  <div className="flex gap-2 mt-2" onClick={(e) => e.stopPropagation()}>
+                  <div
+                    className="flex gap-2 mt-2"
+                    onClick={(e) => e.stopPropagation()}
+                  >
                     <NofxSelect
                       value={config.netflow_ranking_duration || '1h'}
-                      onChange={(val) => !disabled && onChange({ ...config, netflow_ranking_duration: val })}
+                      onChange={(val) =>
+                        !disabled &&
+                        onChange({ ...config, netflow_ranking_duration: val })
+                      }
                       disabled={disabled}
                       className="flex-1 px-2 py-1 rounded text-[10px]"
-                      style={{ background: '#1E2329', border: '1px solid #2B3139', color: '#EAECEF' }}
-                      options={[{ value: '1h', label: '1h' }, { value: '4h', label: '4h' }, { value: '24h', label: '24h' }]}
+                      style={{
+                        background: '#1E2329',
+                        border: '1px solid #2B3139',
+                        color: '#EAECEF',
+                      }}
+                      options={[
+                        { value: '1h', label: '1h' },
+                        { value: '4h', label: '4h' },
+                        { value: '24h', label: '24h' },
+                      ]}
                     />
                     <NofxSelect
                       value={config.netflow_ranking_limit || 10}
-                      onChange={(val) => !disabled && onChange({ ...config, netflow_ranking_limit: parseInt(val) })}
+                      onChange={(val) =>
+                        !disabled &&
+                        onChange({
+                          ...config,
+                          netflow_ranking_limit: parseInt(val),
+                        })
+                      }
                       disabled={disabled}
                       className="w-14 px-2 py-1 rounded text-[10px]"
-                      style={{ background: '#1E2329', border: '1px solid #2B3139', color: '#EAECEF' }}
-                      options={[5, 10, 15, 20].map(n => ({ value: n, label: String(n) }))}
+                      style={{
+                        background: '#1E2329',
+                        border: '1px solid #2B3139',
+                        color: '#EAECEF',
+                      }}
+                      options={[5, 10, 15, 20].map((n) => ({
+                        value: n,
+                        label: String(n),
+                      }))}
                     />
                   </div>
                 )}
@@ -390,73 +535,121 @@ export function IndicatorEditor({
               <div
                 className="p-2.5 rounded-lg transition-all cursor-pointer"
                 style={{
-                  background: config.enable_price_ranking ? 'rgba(236, 72, 153, 0.1)' : 'rgba(30, 35, 41, 0.5)',
-                  border: config.enable_price_ranking ? '1px solid rgba(236, 72, 153, 0.3)' : '1px solid rgba(43, 49, 57, 0.5)',
+                  background: config.enable_price_ranking
+                    ? 'rgba(236, 72, 153, 0.1)'
+                    : 'rgba(30, 35, 41, 0.5)',
+                  border: config.enable_price_ranking
+                    ? '1px solid rgba(236, 72, 153, 0.3)'
+                    : '1px solid rgba(43, 49, 57, 0.5)',
                   opacity: disabled ? 0.5 : 1,
                 }}
-                onClick={() => !disabled && onChange({
-                  ...config,
-                  enable_price_ranking: !config.enable_price_ranking,
-                  ...(!config.enable_price_ranking && !config.price_ranking_duration ? { price_ranking_duration: '1h,4h,24h' } : {}),
-                  ...(!config.enable_price_ranking && !config.price_ranking_limit ? { price_ranking_limit: 10 } : {}),
-                })}
+                onClick={() =>
+                  !disabled &&
+                  onChange({
+                    ...config,
+                    enable_price_ranking: !config.enable_price_ranking,
+                    ...(!config.enable_price_ranking &&
+                    !config.price_ranking_duration
+                      ? { price_ranking_duration: '1h,4h,24h' }
+                      : {}),
+                    ...(!config.enable_price_ranking &&
+                    !config.price_ranking_limit
+                      ? { price_ranking_limit: 10 }
+                      : {}),
+                  })
+                }
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full" style={{ background: '#ec4899' }} />
-                    <span className="text-xs font-medium" style={{ color: '#EAECEF' }}>{ts(indicator.priceRanking, language)}</span>
+                    <div
+                      className="w-2 h-2 rounded-full"
+                      style={{ background: '#ec4899' }}
+                    />
+                    <span
+                      className="text-xs font-medium"
+                      style={{ color: '#EAECEF' }}
+                    >
+                      {ts(indicator.priceRanking, language)}
+                    </span>
                   </div>
                   <input
                     type="checkbox"
                     checked={config.enable_price_ranking || false}
-                    onChange={(e) => { e.stopPropagation(); !disabled && onChange({
-                      ...config,
-                      enable_price_ranking: e.target.checked,
-                      ...(e.target.checked && !config.price_ranking_duration ? { price_ranking_duration: '1h,4h,24h' } : {}),
-                      ...(e.target.checked && !config.price_ranking_limit ? { price_ranking_limit: 10 } : {}),
-                    }) }}
+                    onChange={(e) => {
+                      e.stopPropagation()
+                      !disabled &&
+                        onChange({
+                          ...config,
+                          enable_price_ranking: e.target.checked,
+                          ...(e.target.checked && !config.price_ranking_duration
+                            ? { price_ranking_duration: '1h,4h,24h' }
+                            : {}),
+                          ...(e.target.checked && !config.price_ranking_limit
+                            ? { price_ranking_limit: 10 }
+                            : {}),
+                        })
+                    }}
                     disabled={disabled}
                     className="w-3.5 h-3.5 rounded accent-pink-500"
                   />
                 </div>
-                <p className="text-[10px] mt-1" style={{ color: '#5E6673' }}>{ts(indicator.priceRankingDesc, language)}</p>
+                <p className="text-[10px] mt-1" style={{ color: '#5E6673' }}>
+                  {ts(indicator.priceRankingDesc, language)}
+                </p>
                 {config.enable_price_ranking && (
-                  <div className="flex gap-2 mt-2" onClick={(e) => e.stopPropagation()}>
+                  <div
+                    className="flex gap-2 mt-2"
+                    onClick={(e) => e.stopPropagation()}
+                  >
                     <NofxSelect
                       value={config.price_ranking_duration || '1h,4h,24h'}
-                      onChange={(val) => !disabled && onChange({ ...config, price_ranking_duration: val })}
+                      onChange={(val) =>
+                        !disabled &&
+                        onChange({ ...config, price_ranking_duration: val })
+                      }
                       disabled={disabled}
                       className="flex-1 px-2 py-1 rounded text-[10px]"
-                      style={{ background: '#1E2329', border: '1px solid #2B3139', color: '#EAECEF' }}
+                      style={{
+                        background: '#1E2329',
+                        border: '1px solid #2B3139',
+                        color: '#EAECEF',
+                      }}
                       options={[
                         { value: '1h', label: '1h' },
                         { value: '4h', label: '4h' },
                         { value: '24h', label: '24h' },
-                        { value: '1h,4h,24h', label: ts(indicator.priceRankingMulti, language) },
+                        {
+                          value: '1h,4h,24h',
+                          label: ts(indicator.priceRankingMulti, language),
+                        },
                       ]}
                     />
                     <NofxSelect
                       value={config.price_ranking_limit || 10}
-                      onChange={(val) => !disabled && onChange({ ...config, price_ranking_limit: parseInt(val) })}
+                      onChange={(val) =>
+                        !disabled &&
+                        onChange({
+                          ...config,
+                          price_ranking_limit: parseInt(val),
+                        })
+                      }
                       disabled={disabled}
                       className="w-14 px-2 py-1 rounded text-[10px]"
-                      style={{ background: '#1E2329', border: '1px solid #2B3139', color: '#EAECEF' }}
-                      options={[5, 10, 15, 20].map(n => ({ value: n, label: String(n) }))}
+                      style={{
+                        background: '#1E2329',
+                        border: '1px solid #2B3139',
+                        color: '#EAECEF',
+                      }}
+                      options={[5, 10, 15, 20].map((n) => ({
+                        value: n,
+                        label: String(n),
+                      }))}
                     />
                   </div>
                 )}
               </div>
             </div>
 
-            {/* Warning if features enabled but no API key */}
-            {hasNofxosEnabled && !hasApiKey && (
-              <div className="flex items-center gap-2 mt-3 p-2 rounded-lg" style={{ background: 'rgba(246, 70, 93, 0.1)', border: '1px solid rgba(246, 70, 93, 0.2)' }}>
-                <AlertCircle className="w-4 h-4 flex-shrink-0" style={{ color: '#F6465D' }} />
-                <span className="text-[10px]" style={{ color: '#F6465D' }}>
-                  {ts(indicator.configureApiKey, language)}
-                </span>
-              </div>
-            )}
           </div>
         </div>
       </div>
@@ -464,29 +657,61 @@ export function IndicatorEditor({
       {/* ============================================ */}
       {/* Section 1: Market Data (Required)           */}
       {/* ============================================ */}
-      <div className="rounded-lg overflow-hidden" style={{ background: '#0B0E11', border: '1px solid #2B3139' }}>
-        <div className="px-3 py-2 flex items-center gap-2" style={{ background: '#1E2329', borderBottom: '1px solid #2B3139' }}>
+      <div
+        className="rounded-lg overflow-hidden"
+        style={{ background: '#0B0E11', border: '1px solid #2B3139' }}
+      >
+        <div
+          className="px-3 py-2 flex items-center gap-2"
+          style={{ background: '#1E2329', borderBottom: '1px solid #2B3139' }}
+        >
           <BarChart2 className="w-4 h-4" style={{ color: '#F0B90B' }} />
-          <span className="text-sm font-medium" style={{ color: '#EAECEF' }}>{ts(indicator.marketData, language)}</span>
-          <span className="text-xs" style={{ color: '#848E9C' }}>- {ts(indicator.marketDataDesc, language)}</span>
+          <span className="text-sm font-medium" style={{ color: '#EAECEF' }}>
+            {ts(indicator.marketData, language)}
+          </span>
+          <span className="text-xs" style={{ color: '#848E9C' }}>
+            - {ts(indicator.marketDataDesc, language)}
+          </span>
         </div>
 
         <div className="p-3 space-y-4">
           {/* Raw Klines - Required, Always On */}
-          <div className="flex items-center justify-between p-3 rounded-lg" style={{ background: 'rgba(240, 185, 11, 0.08)', border: '1px solid rgba(240, 185, 11, 0.2)' }}>
+          <div
+            className="flex items-center justify-between p-3 rounded-lg"
+            style={{
+              background: 'rgba(240, 185, 11, 0.08)',
+              border: '1px solid rgba(240, 185, 11, 0.2)',
+            }}
+          >
             <div className="flex items-center gap-3">
-              <div className="w-8 h-8 rounded-lg flex items-center justify-center" style={{ background: 'rgba(240, 185, 11, 0.15)' }}>
+              <div
+                className="w-8 h-8 rounded-lg flex items-center justify-center"
+                style={{ background: 'rgba(240, 185, 11, 0.15)' }}
+              >
                 <TrendingUp className="w-4 h-4" style={{ color: '#F0B90B' }} />
               </div>
               <div>
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium" style={{ color: '#EAECEF' }}>{ts(indicator.rawKlines, language)}</span>
-                  <span className="px-1.5 py-0.5 rounded text-[10px] font-medium flex items-center gap-1" style={{ background: 'rgba(240, 185, 11, 0.2)', color: '#F0B90B' }}>
+                  <span
+                    className="text-sm font-medium"
+                    style={{ color: '#EAECEF' }}
+                  >
+                    {ts(indicator.rawKlines, language)}
+                  </span>
+                  <span
+                    className="px-1.5 py-0.5 rounded text-[10px] font-medium flex items-center gap-1"
+                    style={{
+                      background: 'rgba(240, 185, 11, 0.2)',
+                      color: '#F0B90B',
+                    }}
+                  >
                     <Lock className="w-2.5 h-2.5" />
                     {ts(indicator.required, language)}
                   </span>
                 </div>
-                <p className="text-xs mt-0.5" style={{ color: '#848E9C' }}>{ts(indicator.rawKlinesDesc, language)}</p>
+                <p className="text-xs mt-0.5" style={{ color: '#848E9C' }}>
+                  {ts(indicator.rawKlinesDesc, language)}
+                </p>
               </div>
             </div>
             <input
@@ -502,10 +727,17 @@ export function IndicatorEditor({
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
                 <Clock className="w-3.5 h-3.5" style={{ color: '#848E9C' }} />
-                <span className="text-xs font-medium" style={{ color: '#EAECEF' }}>{ts(indicator.timeframes, language)}</span>
+                <span
+                  className="text-xs font-medium"
+                  style={{ color: '#EAECEF' }}
+                >
+                  {ts(indicator.timeframes, language)}
+                </span>
               </div>
               <div className="flex items-center gap-2">
-                <span className="text-[10px]" style={{ color: '#848E9C' }}>{ts(indicator.klineCount, language)}:</span>
+                <span className="text-[10px]" style={{ color: '#848E9C' }}>
+                  {ts(indicator.klineCount, language)}:
+                </span>
                 <input
                   type="number"
                   value={config.klines.primary_count}
@@ -513,58 +745,89 @@ export function IndicatorEditor({
                     !disabled &&
                     onChange({
                       ...config,
-                      klines: { ...config.klines, primary_count: parseInt(e.target.value) || 30 },
+                      klines: {
+                        ...config.klines,
+                        primary_count: parseInt(e.target.value) || 30,
+                      },
                     })
                   }
                   disabled={disabled}
                   min={10}
                   max={30}
                   className="w-16 px-2 py-1 rounded text-xs text-center"
-                  style={{ background: '#1E2329', border: '1px solid #2B3139', color: '#EAECEF' }}
+                  style={{
+                    background: '#1E2329',
+                    border: '1px solid #2B3139',
+                    color: '#EAECEF',
+                  }}
                 />
               </div>
             </div>
-            <p className="text-[10px] mb-2" style={{ color: '#5E6673' }}>{ts(indicator.timeframesDesc, language)}</p>
+            <p className="text-[10px] mb-2" style={{ color: '#5E6673' }}>
+              {ts(indicator.timeframesDesc, language)}
+            </p>
 
             {/* Timeframe Grid */}
             <div className="space-y-1.5">
-              {(['scalp', 'intraday', 'swing', 'position'] as const).map((category) => {
-                const categoryTfs = allTimeframes.filter((tf) => tf.category === category)
-                return (
-                  <div key={category} className="flex items-center gap-2">
-                    <span className="text-[10px] w-10 flex-shrink-0" style={{ color: categoryColors[category] }}>
-                      {ts(indicator[category], language)}
-                    </span>
-                    <div className="flex flex-wrap gap-1">
-                      {categoryTfs.map((tf) => {
-                        const isSelected = selectedTimeframes.includes(tf.value)
-                        const isPrimary = config.klines.primary_timeframe === tf.value
-                        return (
-                          <button
-                            key={tf.value}
-                            onClick={() => toggleTimeframe(tf.value)}
-                            onDoubleClick={() => setPrimaryTimeframe(tf.value)}
-                            disabled={disabled}
-                            className={`px-2 py-1 rounded text-xs font-medium transition-all ${
-                              isSelected ? '' : 'opacity-40 hover:opacity-70'
-                            }`}
-                            style={{
-                              background: isSelected ? `${categoryColors[category]}15` : 'transparent',
-                              border: `1px solid ${isSelected ? categoryColors[category] : '#2B3139'}`,
-                              color: isSelected ? categoryColors[category] : '#848E9C',
-                              boxShadow: isPrimary ? `0 0 0 2px ${categoryColors[category]}` : undefined,
-                            }}
-                            title={isPrimary ? `${tf.label} (Primary)` : tf.label}
-                          >
-                            {tf.label}
-                            {isPrimary && <span className="ml-0.5 text-[8px]">★</span>}
-                          </button>
-                        )
-                      })}
+              {(['scalp', 'intraday', 'swing', 'position'] as const).map(
+                (category) => {
+                  const categoryTfs = allTimeframes.filter(
+                    (tf) => tf.category === category
+                  )
+                  return (
+                    <div key={category} className="flex items-center gap-2">
+                      <span
+                        className="text-[10px] w-10 flex-shrink-0"
+                        style={{ color: categoryColors[category] }}
+                      >
+                        {ts(indicator[category], language)}
+                      </span>
+                      <div className="flex flex-wrap gap-1">
+                        {categoryTfs.map((tf) => {
+                          const isSelected = selectedTimeframes.includes(
+                            tf.value
+                          )
+                          const isPrimary =
+                            config.klines.primary_timeframe === tf.value
+                          return (
+                            <button
+                              key={tf.value}
+                              onClick={() => toggleTimeframe(tf.value)}
+                              onDoubleClick={() =>
+                                setPrimaryTimeframe(tf.value)
+                              }
+                              disabled={disabled}
+                              className={`px-2 py-1 rounded text-xs font-medium transition-all ${
+                                isSelected ? '' : 'opacity-40 hover:opacity-70'
+                              }`}
+                              style={{
+                                background: isSelected
+                                  ? `${categoryColors[category]}15`
+                                  : 'transparent',
+                                border: `1px solid ${isSelected ? categoryColors[category] : '#2B3139'}`,
+                                color: isSelected
+                                  ? categoryColors[category]
+                                  : '#848E9C',
+                                boxShadow: isPrimary
+                                  ? `0 0 0 2px ${categoryColors[category]}`
+                                  : undefined,
+                              }}
+                              title={
+                                isPrimary ? `${tf.label} (Primary)` : tf.label
+                              }
+                            >
+                              {tf.label}
+                              {isPrimary && (
+                                <span className="ml-0.5 text-[8px]">★</span>
+                              )}
+                            </button>
+                          )
+                        })}
+                      </div>
                     </div>
-                  </div>
-                )
-              })}
+                  )
+                }
+              )}
             </div>
           </div>
         </div>
@@ -573,55 +836,127 @@ export function IndicatorEditor({
       {/* ============================================ */}
       {/* Section 2: Technical Indicators (Optional)  */}
       {/* ============================================ */}
-      <div className="rounded-lg overflow-hidden" style={{ background: '#0B0E11', border: '1px solid #2B3139' }}>
-        <div className="px-3 py-2 flex items-center gap-2" style={{ background: '#1E2329', borderBottom: '1px solid #2B3139' }}>
+      <div
+        className="rounded-lg overflow-hidden"
+        style={{ background: '#0B0E11', border: '1px solid #2B3139' }}
+      >
+        <div
+          className="px-3 py-2 flex items-center gap-2"
+          style={{ background: '#1E2329', borderBottom: '1px solid #2B3139' }}
+        >
           <Activity className="w-4 h-4" style={{ color: '#0ECB81' }} />
-          <span className="text-sm font-medium" style={{ color: '#EAECEF' }}>{ts(indicator.technicalIndicators, language)}</span>
-          <span className="text-xs" style={{ color: '#848E9C' }}>- {ts(indicator.technicalIndicatorsDesc, language)}</span>
+          <span className="text-sm font-medium" style={{ color: '#EAECEF' }}>
+            {ts(indicator.technicalIndicators, language)}
+          </span>
+          <span className="text-xs" style={{ color: '#848E9C' }}>
+            - {ts(indicator.technicalIndicatorsDesc, language)}
+          </span>
         </div>
 
         <div className="p-3">
           {/* Tip */}
-          <div className="flex items-start gap-2 mb-3 p-2 rounded" style={{ background: 'rgba(14, 203, 129, 0.05)' }}>
-            <Info className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" style={{ color: '#0ECB81' }} />
-            <p className="text-[10px]" style={{ color: '#848E9C' }}>{ts(indicator.aiCanCalculate, language)}</p>
+          <div
+            className="flex items-start gap-2 mb-3 p-2 rounded"
+            style={{ background: 'rgba(14, 203, 129, 0.05)' }}
+          >
+            <Info
+              className="w-3.5 h-3.5 mt-0.5 flex-shrink-0"
+              style={{ color: '#0ECB81' }}
+            />
+            <p className="text-[10px]" style={{ color: '#848E9C' }}>
+              {ts(indicator.aiCanCalculate, language)}
+            </p>
           </div>
 
           {/* Indicator Grid */}
           <div className="grid grid-cols-2 gap-2">
             {[
-              { key: 'enable_ema', label: 'ema', desc: 'emaDesc', color: '#F0B90B', periodKey: 'ema_periods', defaultPeriods: '20,50' },
-              { key: 'enable_macd', label: 'macd', desc: 'macdDesc', color: '#a855f7' },
-              { key: 'enable_rsi', label: 'rsi', desc: 'rsiDesc', color: '#F6465D', periodKey: 'rsi_periods', defaultPeriods: '7,14' },
-              { key: 'enable_atr', label: 'atr', desc: 'atrDesc', color: '#60a5fa', periodKey: 'atr_periods', defaultPeriods: '14' },
-              { key: 'enable_boll', label: 'boll', desc: 'bollDesc', color: '#ec4899', periodKey: 'boll_periods', defaultPeriods: '20' },
+              {
+                key: 'enable_ema',
+                label: 'ema',
+                desc: 'emaDesc',
+                color: '#F0B90B',
+                periodKey: 'ema_periods',
+                defaultPeriods: '20,50',
+              },
+              {
+                key: 'enable_macd',
+                label: 'macd',
+                desc: 'macdDesc',
+                color: '#a855f7',
+              },
+              {
+                key: 'enable_rsi',
+                label: 'rsi',
+                desc: 'rsiDesc',
+                color: '#F6465D',
+                periodKey: 'rsi_periods',
+                defaultPeriods: '7,14',
+              },
+              {
+                key: 'enable_atr',
+                label: 'atr',
+                desc: 'atrDesc',
+                color: '#60a5fa',
+                periodKey: 'atr_periods',
+                defaultPeriods: '14',
+              },
+              {
+                key: 'enable_boll',
+                label: 'boll',
+                desc: 'bollDesc',
+                color: '#ec4899',
+                periodKey: 'boll_periods',
+                defaultPeriods: '20',
+              },
             ].map(({ key, label, desc, color, periodKey, defaultPeriods }) => (
               <div
                 key={key}
                 className="p-2.5 rounded-lg transition-all"
                 style={{
-                  background: config[key as keyof IndicatorConfig] ? `${color}08` : 'transparent',
+                  background: config[key as keyof IndicatorConfig]
+                    ? `${color}08`
+                    : 'transparent',
                   border: `1px solid ${config[key as keyof IndicatorConfig] ? `${color}30` : '#2B3139'}`,
                 }}
               >
                 <div className="flex items-center justify-between mb-1">
                   <div className="flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full" style={{ background: color }} />
-                    <span className="text-xs font-medium" style={{ color: '#EAECEF' }}>{ts(indicator[label as keyof typeof indicator], language)}</span>
+                    <div
+                      className="w-2 h-2 rounded-full"
+                      style={{ background: color }}
+                    />
+                    <span
+                      className="text-xs font-medium"
+                      style={{ color: '#EAECEF' }}
+                    >
+                      {ts(indicator[label as keyof typeof indicator], language)}
+                    </span>
                   </div>
                   <input
                     type="checkbox"
-                    checked={config[key as keyof IndicatorConfig] as boolean || false}
-                    onChange={(e) => !disabled && onChange({ ...config, [key]: e.target.checked })}
+                    checked={
+                      (config[key as keyof IndicatorConfig] as boolean) || false
+                    }
+                    onChange={(e) =>
+                      !disabled &&
+                      onChange({ ...config, [key]: e.target.checked })
+                    }
                     disabled={disabled}
                     className="w-4 h-4 rounded accent-yellow-500"
                   />
                 </div>
-                <p className="text-[10px] mb-1.5" style={{ color: '#5E6673' }}>{ts(indicator[desc as keyof typeof indicator], language)}</p>
+                <p className="text-[10px] mb-1.5" style={{ color: '#5E6673' }}>
+                  {ts(indicator[desc as keyof typeof indicator], language)}
+                </p>
                 {periodKey && config[key as keyof IndicatorConfig] && (
                   <input
                     type="text"
-                    value={(config[periodKey as keyof IndicatorConfig] as number[])?.join(',') || defaultPeriods}
+                    value={
+                      (
+                        config[periodKey as keyof IndicatorConfig] as number[]
+                      )?.join(',') || defaultPeriods
+                    }
                     onChange={(e) => {
                       if (disabled) return
                       const periods = e.target.value
@@ -633,7 +968,11 @@ export function IndicatorEditor({
                     disabled={disabled}
                     placeholder={defaultPeriods}
                     className="w-full px-2 py-1 rounded text-[10px] text-center"
-                    style={{ background: '#1E2329', border: '1px solid #2B3139', color: '#EAECEF' }}
+                    style={{
+                      background: '#1E2329',
+                      border: '1px solid #2B3139',
+                      color: '#EAECEF',
+                    }}
                   />
                 )}
               </div>
@@ -645,42 +984,84 @@ export function IndicatorEditor({
       {/* ============================================ */}
       {/* Section 3: Market Sentiment                 */}
       {/* ============================================ */}
-      <div className="rounded-lg overflow-hidden" style={{ background: '#0B0E11', border: '1px solid #2B3139' }}>
-        <div className="px-3 py-2 flex items-center gap-2" style={{ background: '#1E2329', borderBottom: '1px solid #2B3139' }}>
+      <div
+        className="rounded-lg overflow-hidden"
+        style={{ background: '#0B0E11', border: '1px solid #2B3139' }}
+      >
+        <div
+          className="px-3 py-2 flex items-center gap-2"
+          style={{ background: '#1E2329', borderBottom: '1px solid #2B3139' }}
+        >
           <TrendingUp className="w-4 h-4" style={{ color: '#22c55e' }} />
-          <span className="text-sm font-medium" style={{ color: '#EAECEF' }}>{ts(indicator.marketSentiment, language)}</span>
-          <span className="text-xs" style={{ color: '#848E9C' }}>- {ts(indicator.marketSentimentDesc, language)}</span>
+          <span className="text-sm font-medium" style={{ color: '#EAECEF' }}>
+            {ts(indicator.marketSentiment, language)}
+          </span>
+          <span className="text-xs" style={{ color: '#848E9C' }}>
+            - {ts(indicator.marketSentimentDesc, language)}
+          </span>
         </div>
 
         <div className="p-3">
           <div className="grid grid-cols-3 gap-2">
             {[
-              { key: 'enable_volume', label: 'volume', desc: 'volumeDesc', color: '#c084fc' },
-              { key: 'enable_oi', label: 'oi', desc: 'oiDesc', color: '#34d399' },
-              { key: 'enable_funding_rate', label: 'fundingRate', desc: 'fundingRateDesc', color: '#fbbf24' },
+              {
+                key: 'enable_volume',
+                label: 'volume',
+                desc: 'volumeDesc',
+                color: '#c084fc',
+              },
+              {
+                key: 'enable_oi',
+                label: 'oi',
+                desc: 'oiDesc',
+                color: '#34d399',
+              },
+              {
+                key: 'enable_funding_rate',
+                label: 'fundingRate',
+                desc: 'fundingRateDesc',
+                color: '#fbbf24',
+              },
             ].map(({ key, label, desc, color }) => (
               <div
                 key={key}
                 className="p-2.5 rounded-lg transition-all"
                 style={{
-                  background: config[key as keyof IndicatorConfig] ? `${color}08` : 'transparent',
+                  background: config[key as keyof IndicatorConfig]
+                    ? `${color}08`
+                    : 'transparent',
                   border: `1px solid ${config[key as keyof IndicatorConfig] ? `${color}30` : '#2B3139'}`,
                 }}
               >
                 <div className="flex items-center justify-between mb-1">
                   <div className="flex items-center gap-2">
-                    <div className="w-2 h-2 rounded-full" style={{ background: color }} />
-                    <span className="text-xs font-medium" style={{ color: '#EAECEF' }}>{ts(indicator[label as keyof typeof indicator], language)}</span>
+                    <div
+                      className="w-2 h-2 rounded-full"
+                      style={{ background: color }}
+                    />
+                    <span
+                      className="text-xs font-medium"
+                      style={{ color: '#EAECEF' }}
+                    >
+                      {ts(indicator[label as keyof typeof indicator], language)}
+                    </span>
                   </div>
                   <input
                     type="checkbox"
-                    checked={config[key as keyof IndicatorConfig] as boolean || false}
-                    onChange={(e) => !disabled && onChange({ ...config, [key]: e.target.checked })}
+                    checked={
+                      (config[key as keyof IndicatorConfig] as boolean) || false
+                    }
+                    onChange={(e) =>
+                      !disabled &&
+                      onChange({ ...config, [key]: e.target.checked })
+                    }
                     disabled={disabled}
                     className="w-4 h-4 rounded accent-yellow-500"
                   />
                 </div>
-                <p className="text-[10px]" style={{ color: '#5E6673' }}>{ts(indicator[desc as keyof typeof indicator], language)}</p>
+                <p className="text-[10px]" style={{ color: '#5E6673' }}>
+                  {ts(indicator[desc as keyof typeof indicator], language)}
+                </p>
               </div>
             ))}
           </div>

--- a/web/src/i18n/strategy-translations.ts
+++ b/web/src/i18n/strategy-translations.ts
@@ -30,7 +30,6 @@ export const coinSource = {
   excludedCoins: { zh: '排除币种', en: 'Excluded Coins', es: 'Monedas Excluidas' },
   excludedCoinsDesc: { zh: '这些币种将从所有数据源中排除，不会被交易', en: 'These coins will be excluded from all sources and will not be traded', es: 'Estas monedas serán excluidas de todas las fuentes' },
   addExcludedCoin: { zh: '添加排除', en: 'Add Excluded', es: 'Agregar Excluida' },
-  nofxosNote: { zh: '使用 NofxOS API Key（在指标配置中设置）', en: 'Uses NofxOS API Key (set in Indicators config)', es: 'Usa API Key de NofxOS' },
   ai500Desc: { zh: '使用 AI500 智能筛选的热门币种', en: 'Use AI500 smart-filtered popular coins', es: 'Monedas filtradas por AI500' },
   oi_topDesc: { zh: '持仓增加榜，适合做多', en: 'OI increase ranking, for long', es: 'Ranking OI creciente, para largo' },
   oi_lowDesc: { zh: '持仓减少榜，适合做空', en: 'OI decrease ranking, for short', es: 'Ranking OI decreciente, para corto' },
@@ -246,13 +245,7 @@ export const indicator = {
   nofxosDesc: { zh: '专业加密货币量化数据服务', en: 'Professional crypto quant data service', es: 'Servicio crypto quant' },
   nofxosFeatures: { zh: 'AI500 · OI排行 · 资金流向 · 涨跌榜', en: 'AI500 · OI Ranking · Fund Flow · Price Ranking', es: 'AI500 · OI · NetFlow · Ranking' },
   viewApiDocs: { zh: 'API 文档', en: 'API Docs', es: 'Docs API' },
-  apiKey: { zh: 'API Key', en: 'API Key', es: 'API Key' },
-  apiKeyPlaceholder: { zh: '输入 NofxOS API Key', en: 'Enter NofxOS API Key', es: 'Ingresar API Key' },
-  fillDefault: { zh: '填入默认', en: 'Fill Default', es: 'Llenar Default' },
-  connected: { zh: '已配置', en: 'Configured', es: 'Configurado' },
-  notConfigured: { zh: '未配置', en: 'Not Configured', es: 'No Configurado' },
   nofxosDataSources: { zh: 'NofxOS 数据源', en: 'NofxOS Data Sources', es: 'Fuentes NofxOS' },
-  configureApiKey: { zh: '请配置 API Key 以启用 NofxOS 数据源', en: 'Please configure API Key to enable NofxOS data sources', es: 'Configure API Key para habilitar NofxOS' },
 };
 
 // ============================================================================

--- a/web/src/types/strategy.ts
+++ b/web/src/types/strategy.ts
@@ -119,10 +119,6 @@ export interface IndicatorConfig {
   boll_periods?: number[];
   external_data_sources?: ExternalDataSource[];
 
-  // ========== NofxOS 数据源统一配置 ==========
-  // Unified NofxOS API Key - used for all NofxOS data sources
-  nofxos_api_key?: string;
-
   // 量化数据源（资金流向、持仓变化、价格变化）
   enable_quant_data?: boolean;
   enable_quant_oi?: boolean;


### PR DESCRIPTION
## Summary

Remove the hardcoded NofxOS API key (`cm_568c67eae410d912c54c`) and all associated configuration fields, validation, UI, and translations. NofxOS data service no longer requires an API key — all requests are now routed through the claw402 x402 payment gateway.

### Changes

**Backend:**
- `store/strategy.go`: Remove `NofxOSAPIKey` field from `IndicatorConfig` and its default value from `GetDefaultStrategyConfig()`
- `provider/nofxos/client.go`: Remove `DefaultAuthKey` constant, fallback logic in `NewClient()`, and key from `DefaultClient()`
- `kernel/engine.go`: Simplify client creation — pass empty auth key since claw402 handles routing
- `api/strategy.go`: Remove API key validation from `validateStrategyConfig()`
- `api/server.go`: Remove `indicators.nofxos_api_key` from the AI prompt guide

**Frontend:**
- `web/src/types/strategy.ts`: Remove `nofxos_api_key` from `IndicatorConfig` type
- `web/src/components/strategy/IndicatorEditor.tsx`: Remove API key constant, status badges, warning, and unused imports
- `web/src/i18n/strategy-translations.ts`: Remove unused translation keys (`apiKey`, `connected`, `notConfigured`, `configureApiKey`, etc.)

## Test plan

- [x] `go build ./...` — no compilation errors
- [x] `go vet ./...` — no issues
- [x] `npm run build` — clean build
- [x] `npm run lint` — no new warnings in changed files